### PR TITLE
Add script for fetching Noto Sans font

### DIFF
--- a/fetch-noto-sans.sh
+++ b/fetch-noto-sans.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+if [ -d fonts ]; then
+  echo "fonts directory already exists"
+  exit 1
+fi
+
+TTF_DIR="fonts/NotoSans/googlefonts/ttf"
+
+mkdir -p fonts
+cd fonts
+git clone --filter=blob:none --no-checkout https://github.com/notofonts/notofonts.github.io.git
+cd notofonts.github.io
+git sparse-checkout set --cone "$TTF_DIR"
+git checkout main
+cp "$TTF_DIR"/*.ttf ..
+cd ..
+rm -rf notofonts.github.io


### PR DESCRIPTION
The [build instruction for Windows](https://github.com/Taiko2k/TauonMusicBox/wiki/Building-for-Windows) has this manual step. This script automates getting the Noto Sans font from the source.

https://fonts.google.com/noto/specimen/Noto+Sans links to https://github.com/notofonts/noto-source, which then says to go to https://notofonts.github.io/.