### PR TITLE
replace isounidecode with unidecode

### DIFF
--- a/extra/win-requirements.txt
+++ b/extra/win-requirements.txt
@@ -8,7 +8,7 @@ requests
 beautifulsoup4
 PlexAPI
 musicbrainzngs
-isounidecode
+unidecode
 infi.systray
 mutagen
 natsort

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ requests
 beautifulsoup4
 PlexAPI
 musicbrainzngs
-isounidecode
+unidecode
 setproctitle
 mutagen
 natsort

--- a/t_modules/t_lyrics.py
+++ b/t_modules/t_lyrics.py
@@ -18,7 +18,7 @@
 #     along with Tauon Music Box.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from isounidecode import unidecode
+from unidecode import unidecode
 from bs4 import BeautifulSoup
 import urllib.parse
 import requests
@@ -81,7 +81,7 @@ def genius(artist, title, return_url=False):
     line = line.replace("/", "-")
     line = line.replace("-&-", "-and-")
     line = line.replace("&", "-and-")
-    line = unidecode(line).decode()
+    line = unidecode(line)
     line = urllib.parse.quote(line)
     line = f"https://genius.com/{line}-lyrics"
 

--- a/t_modules/t_main.py
+++ b/t_modules/t_main.py
@@ -591,7 +591,7 @@ from pathlib import Path
 from xml.sax.saxutils import escape, unescape
 from ctypes import *
 from send2trash import send2trash
-from isounidecode import unidecode
+from unidecode import unidecode
 from collections import OrderedDict
 
 musicbrainzngs.set_useragent("TauonMusicBox", n_version, "https://github.com/Taiko2k/Tauon")
@@ -25663,14 +25663,14 @@ def worker2():
                                         s_text = s_cn
 
                         if dia_mode:
-                            title = unidecode(title).decode()
+                            title = unidecode(title)
 
-                            artist = unidecode(artist).decode()
-                            album_artist = unidecode(album_artist).decode()
-                            composer = unidecode(composer).decode()
-                            album = unidecode(album).decode()
-                            filename = unidecode(filename).decode()
-                            sartist = unidecode(sartist).decode()
+                            artist = unidecode(artist)
+                            album_artist = unidecode(album_artist)
+                            composer = unidecode(composer)
+                            album = unidecode(album)
+                            filename = unidecode(filename)
+                            sartist = unidecode(sartist)
 
                             if cache_string is None:
                                 search_dia_string_cache[
@@ -30054,9 +30054,9 @@ class Over:
                               click=self.click, replace="github")
 
             y += spacing
-            ddt.text((x, y), "isounidecode", colours.box_sub_text, font)
-            ddt.text((xx, y), "New BSD License", colours.box_text_label, font)
-            draw_linked_text2(xxx, y, "https://github.com/redvasily/isounidecode", colours.box_sub_text, font,
+            ddt.text((x, y), "unidecode", colours.box_sub_text, font)
+            ddt.text((xx, y), "GPL-2.0+", colours.box_text_label, font)
+            draw_linked_text2(xxx, y, "https://github.com/avian2/unidecode", colours.box_sub_text, font,
                               click=self.click, replace="github")
 
             y += spacing


### PR DESCRIPTION
isounidecode don't have any new commits (nor releases) since 7 years ago. Also, seems that distros don't tend to package it (at least Gentoo, Debian and Fedora). 
Unidecode seems to be API compatible and work out of the box and is more active.