### PR TITLE
add jellyfin genres

### DIFF
--- a/t_modules/t_jellyfin.py
+++ b/t_modules/t_jellyfin.py
@@ -428,6 +428,7 @@ class Jellyfin():
                     "x-emby-authorization": self._get_jellyfin_auth()
                 },
                 params={
+                    "fields": "Genres", #Specify additional field to return
                     "recursive": True,
                     "filter": "music"
                 },
@@ -483,6 +484,8 @@ class Jellyfin():
                 nt.album = track.get("Album", "")
                 nt.length = track.get("RunTimeTicks", 0) / 10000000   # needs to be in seconds
                 nt.date = str(track.get("ProductionYear"))
+                genres = track.get("Genres", [])
+                nt.genre = "; ".join(genres)
 
                 folder_name = nt.album_artist
                 if folder_name and nt.album:


### PR DESCRIPTION
This pull request is for adding Genres to a Jellyfin playlist/collection.

Genres are not included by default in the GET response of the Items endpoint. According to the Jellyfin API documentation, the "fields" parameter allows you to "Specify additional fields of information to return in the output." One of those fields is Genres.
https://api.jellyfin.org/#tag/Items/operation/GetItems

I changed the Jellfyin module to add a "fields" parameter to include the Genres field, and naturally added a variable to capture the Genre(s) in the Jellyfin import loop.

I've tested the changes and everything seems to work. Genres appear in the columns view of the Jellyfin Collection and I'm able to filter and create playlists based on the Genre.

