### PR TITLE
Specify Audio MediaStreams

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,9 @@ Wanna contribute? Theres a few ways you can:
 
 ## Questions
 
-You feel free to ask questions as a new Github issue. Please do not comment in an existing or old issue unless you're the author or you're sure its directly releated.
+You feel free to ask questions as a new Github issue. Please do not comment in an existing or old issue unless you're the author or you're sure its directly related.
 
-You can also use the github discussions feature. 
+You can also use the github discussions feature.
 
 If you use Discord it may be faster to ask on the official server.
 
@@ -23,7 +23,7 @@ If you encounter an issue, feel free to create new issues on github.
  - What method did you use to install Tauon? 
     - Flatpak? Snap? AUR? Other/Manual?
  - What version number is shown under MENU > Settings... > About
- - For audio/transition related issues, what backend do you have selected under MENU > Settings... > Audio. Does the issue happen on both backends? Are you playing local files, or files from a particuar network server?
+ - For audio/transition related issues, what backend do you have selected under MENU > Settings... > Audio. Does the issue happen on both backends? Are you playing local files, or files from a particular network server?
  - For crashes, it would be most helpful if you could replicate the crash and capture the error from terminal output.
     - To run manually for AUR install: `tauon`. For Flatpak: `flatpak run com.github.taiko2k.tauonmb`
 
@@ -36,7 +36,7 @@ Design concepts would be interesting to see, but you should check with me before
 
 ## Code Contributions
 
-The code base for core and UI related elements is very (very) messy, and there are strict design requiements, as such I don't expect code contributions for these things.
+The code base for core and UI related elements is very (very) messy, and there are strict design requirements, as such I don't expect code contributions for these things.
 
 Tauon's submodules are more manageable to work on.
 

--- a/t_modules/t_jellyfin.py
+++ b/t_modules/t_jellyfin.py
@@ -388,7 +388,7 @@ class Jellyfin():
                 params={
                     "userId": self.userId,
                     "fields": ["Genres","DateCreated","MediaSources","People"],
-                    "enableImages": 'false',
+                    "enableImages": False,
                     "mediaTypes": ["Audio"],
                     "recursive": True,
                 },
@@ -456,24 +456,27 @@ class Jellyfin():
                     for d in track.get("People", [])
                     if d["Type"] == "Composer")
                 nt.length = track.get("RunTimeTicks", 0) / 10000000   # needs to be in seconds
-                nt.bitrate = round((track.get("MediaSources")[0]
-                    ["MediaStreams"][0]["BitRate"] / 1000))
-                nt.samplerate = round((track.get("MediaSources")[0]
-                    ["MediaStreams"][0].get("SampleRate", 0)))
-                nt.bit_depth = (track.get("MediaSources")[0]
-                    ["MediaStreams"][0].get("BitDepth", 0))
                 nt.album = track.get("Album", "")
-                nt.date = str(track.get("ProductionYear"))
+                nt.date = str(track.get("ProductionYear", ""))
                 nt.track_number = str(track.get("IndexNumber", ""))
                 genres = track.get("Genres", [])
                 nt.genre = "; ".join(genres)
-                nt.comment = (track.get("MediaSources")[0]
-                    ["MediaStreams"][0].get("Comment", ""))
                 nt.disc_number = str(track.get("ParentIndexNumber", ""))
 
                 try:
-                    nt.misc["container"] = track.get("MediaSources")[0]["Container"].upper()
-                    nt.misc["codec"] = track.get("MediaSources")[0]["MediaStreams"][0]["Codec"]
+                    for d in track.get("MediaSources")[0]["MediaStreams"]:
+                        if d["Type"] == "Audio":
+                            nt.bitrate = round(d.get("BitRate", 0) / 1000)
+                            nt.samplerate = round(d.get("SampleRate", 0))
+                            nt.bit_depth = d.get("BitDepth", 0)
+                            nt.comment = d.get("Comment", "")
+                            nt.misc["codec"] = d.get("Codec", "")
+                            break
+                except:
+                    print("Jelly error getting audio mediastream")
+
+                try:
+                    nt.misc["container"] = track.get("MediaSources")[0].get("Container", "").upper()
                 except:
                     print("Jelly error get container")
 


### PR DESCRIPTION
In the Jellyfin json response there can be more than one "MediaStreams" dictionary. In my audio files the first (or only) one is usually audio, but I've discovered in some cases the first stream is cover art.

This pull request ensures that the TrackClass attributes populated from the MediaStreams dictionary is from the audio media stream rather than some other. I was also sure to include a default in the event one of the attributes were missing.

I've also added a fallback empty string for the nt.date and nt.container attributes in the event they are missing, as well as changing the enableImages query parameter from 'false' to False (it works either way, but the latter seems more "correct"). All the other attributes already have a fallback, or do not need one because it would otherwise not exist (e.g. file path, size, modified date).

By the way, setting enableImages to False will not impact cover art displaying because the GET response will still include the "AlbumPrimaryImageTag" used by the get_cover method. By setting enableImages to False I am able to reduce the size of the json response by ~30MB for my library, which isn't much, but does further reduce the size of the json response.

I have tested these changes to ensure that it functions correctly. 

These changes will pull the data from the first audio stream. I suppose technically there could be more than one audio media stream in a music file. At this time, I'm not sure what should be done in the case of a second audio stream in a music file but, while I've seen multiple audio streams in video files, it seems like it would be extremely unusual and rare for music files.
