### PR TITLE
Flipped `artist` and `track name` in Discord Rich Presence

### DIFF
--- a/t_modules/t_main.py
+++ b/t_modules/t_main.py
@@ -24094,7 +24094,7 @@ def discord_loop():
             title = "Unknown Track"
             tr = pctl.playing_object()
             if tr.artist != "" and tr.title != "":
-                title = tr.artist + " - " + tr.title
+                title = tr.title + " | " + tr.artist
                 if len(title) > 150:
                     title = "Unknown Track"
 


### PR DESCRIPTION
Also made separator into `|` instead of `-`, which I think improves visual separation.

I made this change because long artist names would often completely obscure the song name in Discord, while I prefer if the song name itself is visible over the artist. While updating my tags to have shorter artist names and removing featured artists could work, I think this is a preferable solution.

Some examples follow. I highlighted the song title with a red box.

## Examples:
#### Old
![image](https://github.com/user-attachments/assets/7b673352-65b2-462b-98cc-2012a903720f)
#### New
![image](https://github.com/user-attachments/assets/169de97c-ef1d-4151-8a82-580191a779b4)

---

#### Old
![image](https://github.com/user-attachments/assets/bb0bf080-025a-4844-85eb-14d26a902855)
#### New
![image](https://github.com/user-attachments/assets/75dfd555-f4d2-4cd7-9675-72ee02757b53)

---

#### Old
![image](https://github.com/user-attachments/assets/4adb7e66-981c-4fd0-bee7-370a11f50a28)
#### New
![image](https://github.com/user-attachments/assets/7a6903cc-23e7-419a-bf8d-83e633303330)