### PR TITLE
Add basic linter rules and partially type Phazor, Spotify and Webserve

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,9 @@ target-version = "py39"
 line-length = 120
 
 [tool.ruff.lint.flake8-quotes]
-inline-quotes = 'single'
+inline-quotes = 'double'
 docstring-quotes = 'double'
 
 [tool.ruff.format]
-quote-style = 'single'
+quote-style = 'double'
 indent-style = 'space' # Change to tabs?
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[tool.ruff]
+# Target non-EOL releases at minimum - https://devguide.python.org/versions/
+target-version = "py39"
+# Soft 80 and hard break at 120
+line-length = 120
+
+[tool.ruff.lint.flake8-quotes]
+inline-quotes = 'single'
+docstring-quotes = 'double'
+
+[tool.ruff.format]
+quote-style = 'single'
+indent-style = 'space' # Change to tabs?
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,4 +10,4 @@ docstring-quotes = 'double'
 
 [tool.ruff.format]
 quote-style = 'double'
-indent-style = 'space' # Change to tabs?
+indent-style = 'tab'

--- a/t_modules/t_main.py
+++ b/t_modules/t_main.py
@@ -1,7 +1,12 @@
-#! /usr/bin/env python3
-# -*- coding: utf-8 -*-
+"""Tauon Music Box
 
-# Tauon Music Box
+Preamble
+
+Welcome to the Tauon Music Box source code. I started this project when I was first
+learning python, as a result this code can be quite messy. No doubt I have
+written some things terribly wrong or inefficiently in places.
+I would highly recommend not using this project as an example on how to code cleanly or correctly.
+"""
 
 # Copyright © 2015-2024, Taiko2k captain(dot)gxj(at)gmail.com
 
@@ -18,21 +23,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# --------------------------------------------------------------------
-# Preamble
-
-# Welcome to the Tauon Music Box source code. I started this project when I was first
-# learning python, as a result this code can be quite messy. No doubt I have
-# written some things terribly wrong or inefficiently in places.
-# I would highly recommend not using this project as an example on how to code cleanly or correctly.
-
-# --------------------------------------------------------------------
-
+from __future__ import annotations
 import sys
 import socket
 
 from t_modules import t_bootstrap
 from t_modules.t_phazor import player4, phazor_exists
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from t_modules.t_phazor import Cachement, LibreSpot
 
 
 h = t_bootstrap.holder
@@ -5214,7 +5213,7 @@ class PlayerCtl:
         # Database
 
         self.master_count = master_count
-        self.total_playtime = 0
+        self.total_playtime: float = 0
         self.master_library = master_library
         self.db_inc = random.randint(0, 10000)
         # self.star_library = star_library
@@ -8369,7 +8368,7 @@ class Tauon:
         self.desktop = desktop
         self.device = socket.gethostname()
 
-        self.cachement = None
+        self.cachement: Cachement | None = None
         self.dummy_event = SDL_Event()
         self.translate = _
         self.strings = strings
@@ -8416,7 +8415,7 @@ class Tauon:
 
         self.copied_track = None
         self.macos = macos
-        self.aud = None
+        self.aud: CDLL | None = None
 
         self.recorded_songs = []
         self.ca = None
@@ -8429,12 +8428,15 @@ class Tauon:
         self.remote_limited = True
         self.enable_librespot = shutil.which("librespot")
 
-        self.spotc = None
+        self.spotc: LibreSpot | None = None
         self.librespot_p = None
         self.MenuItem = MenuItem
         self.tag_scan = tag_scan
 
         self.gme_formats = GME_Formats
+
+        self.spot_ctl: SpotCtl | None = None
+        self.chrome: Chrome | None = None
 
     def start_remote(self):
 

--- a/t_modules/t_spot.py
+++ b/t_modules/t_spot.py
@@ -16,6 +16,7 @@
 #     along with Tauon Music Box.  If not, see <http://www.gnu.org/licenses/>.
 
 
+from __future__ import annotations
 import os
 try:
     import tekore as tk
@@ -31,11 +32,14 @@ import subprocess
 import time
 import json
 from t_modules.t_extra import Timer
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from t_modules.t_main import Tauon
 
 
 class SpotCtl:
 
-    def __init__(self, tauon):
+    def __init__(self, tauon: Tauon):
         self.tauon = tauon
         self.strings = tauon.strings
         self.start_timer = Timer()

--- a/t_modules/t_webserve.py
+++ b/t_modules/t_webserve.py
@@ -35,7 +35,7 @@ from socketserver import ThreadingMixIn
 from t_modules.t_extra import Timer
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
-    from t_modules.t_main import Tauon
+    from t_modules.t_main import Tauon, PlayerCtl
 
 def send_file(path, mime, server):
     range_req = False
@@ -75,7 +75,7 @@ def send_file(path, mime, server):
                 break
             server.wfile.write(data)
 
-def webserve(pctl, prefs, gui, album_art_gen, install_directory, strings, tauon: Tauon):
+def webserve(pctl: PlayerCtl, prefs, gui, album_art_gen, install_directory, strings, tauon: Tauon):
 
     if prefs.enable_web is False:
         return 0
@@ -227,7 +227,7 @@ def webserve(pctl, prefs, gui, album_art_gen, install_directory, strings, tauon:
         print("Not starting radio page server, already running?")
 
 
-def webserve2(pctl, prefs, gui, album_art_gen, install_directory, strings, tauon: Tauon):
+def webserve2(pctl: PlayerCtl, prefs, gui, album_art_gen, install_directory, strings, tauon: Tauon):
 
     play_timer = Timer()
 


### PR DESCRIPTION
Follow up to #1251.

There's a couple things to go through:

* Single vs Double quotes - it would be nice to consistently use one formatting
The codebase uses quotes pretty much randomly:
![image](https://github.com/user-attachments/assets/83b36154-c0a7-4975-b784-b170619a686f)  
I've added a linter rule that ensures single quotes everywhere (docstrings remain double quoted, as per PEP recommendations).  
If double quotes are desired instead, let me know and I'll swap it.

* Spaces vs tabs - It would be nice to use tab indents, as that will allow everyone to view the code at the indentation width they prefer  
Using tabs goes directly against PEP8. In my opinion, this PEP8 recommendation is nonsense today, as Python handles indentation amazingly for both, and tabs allow people their own indent preference.  
Everyone uses something else - I prefer 2-width, htop uses 3-width, TMB uses 4-width and Linux uses 8-width.  
Tabs allow people to set their editors to display what they want.  
Editors had poor support for setting indent width in the past, which is why we're historically stuck with things like the PEP8 recc.  
Currently, the PR has spaces in the linter, as that's what the codebase uses.  
If conversion would be agreeable, it's not necessary to convert the entire code base at once (which would be impossible as indents are not consistent even now, this PR fixes one such case, and using tabs has considerations for their dynamic sizing), but Python allows separate files to have different indents from other files, or even within the same file for different functions, one just can't mix them for code within the same function block.

* Removed wildcard imports  
I was able to remove the wildcard imports from phazor, but was not able to test properly due to build system issues below, so it might be a good idea to test that it still runs on both Linux + Windows.

* Platform checks  
I have swapped `tauon.msys` checks, which I understand are currently used as a kinda check for both win32 + windows terminal that does not support Unicode well (is this still the case?), for `sys.platform == "win32"` checks in the Phazor files.  
I think that at least in here that will work correctly, but I it would be nice to take a look that I did not mess it up.  
This was necessary to make type checkers to work, as they otherwise try to include the Windows code when on Linux.

* Current build system  
This is a ticket for another PR, but Tauon currently relies on the old `setup.py` over `pyproject.toml` (which this PR uses to add linter rules).  
I believe Phazor needs to somehow be built first before launching tauon.py, but running `compile-phazor.sh` just errors on missing miniaudio... is there a proper build script somewhere in the project files? I am aware I can just copy build steps from AUR PKGBUILDs.  
Would be nice if this built outright from `pyproject.toml`.

The rest is just adding more typing, and adding some missing variables to the Tauon class.  
Would have added more things, but it feels like enough changes for one PR and it'll probably be best to figure out how to properly build and test before I move on :)