### PR TITLE
main, db_migrate: Hotfix user_directory and convert config_directory to Path

### DIFF
--- a/src/tauon/t_modules/t_db_migrate.py
+++ b/src/tauon/t_modules/t_db_migrate.py
@@ -20,7 +20,7 @@ def database_migrate(
 	star_store: StarStore,
 	a_cache_dir: str,
 	cache_directory: Path,
-	config_directory: str,
+	config_directory: Path,
 	install_directory: str,
 	user_directory: str,
 	gui: GuiVar,
@@ -185,8 +185,8 @@ def database_migrate(
 		for key, value in master_library.items():
 			setattr(master_library[key], "composer", "")
 
-		if install_directory != config_directory and os.path.isfile(os.path.join(config_directory, "input.txt")):
-			with open(os.path.join(config_directory, "input.txt"), "a") as f:
+		if install_directory != config_directory and Path(config_directory / "input.txt").is_file():
+			with Path(config_directory / "input.txt").open("a") as f:
 				f.write("global-search G Ctrl\n")
 				f.write("cycle-theme-reverse\n")
 				f.write("reload-theme F10\n")
@@ -203,8 +203,8 @@ def database_migrate(
 
 	if db_version <= 31:
 
-		if install_directory != config_directory and os.path.isfile(os.path.join(config_directory, "input.txt")):
-			with open(os.path.join(config_directory, "input.txt"), "a") as f:
+		if install_directory != config_directory and Path(config_directory / "input.txt").is_file():
+			with Path(config_directory / "input.txt").open("a") as f:
 				f.write("love-selected\n")
 		gui.set_bar = True
 
@@ -225,15 +225,15 @@ def database_migrate(
 	if db_version <= 35:
 		logging.info("Updating database to version 36")
 
-		if install_directory != config_directory and os.path.isfile(os.path.join(config_directory, "input.txt")):
-			with open(os.path.join(config_directory, "input.txt"), "a") as f:
+		if install_directory != config_directory and Path(config_directory / "input.txt").is_file():
+			with Path(config_directory / "input.txt").open("a") as f:
 				f.write("toggle-show-art H Ctrl\n")
 
 	if db_version <= 37:
 		logging.info("Updating database to version 38")
 
-		if install_directory != config_directory and os.path.isfile(os.path.join(config_directory, "input.txt")):
-			with open(os.path.join(config_directory, "input.txt"), "a") as f:
+		if install_directory != config_directory and Path(config_directory / "input.txt").is_file():
+			with Path(config_directory / "input.txt").open("a") as f:
 				f.write("toggle-console `\n")
 
 	if db_version <= 38:
@@ -248,13 +248,13 @@ def database_migrate(
 	if db_version <= 39:
 		logging.info("Updating database to version 40")
 
-		if install_directory != config_directory and os.path.isfile(os.path.join(config_directory, "input.txt")):
-			f = open(os.path.join(config_directory, "input.txt"), "r")
+		if install_directory != config_directory and Path(config_directory / "input.txt").is_file():
+			f = Path(config_directory / "input.txt").open("r")
 			text = f.read()
 			f.close()
 			lines = text.splitlines()
 			if "l ctrl" not in text.lower():
-				f = open(os.path.join(config_directory, "input.txt"), "w")
+				f = Path(config_directory / "input.txt").open("w")
 				for line in lines:
 					line = line.strip()
 					if line == "love-selected":
@@ -279,13 +279,13 @@ def database_migrate(
 		for key, value in gen_codes.items():
 			gen_codes[key] = value.replace("f\"", "p\"")
 
-		if install_directory != config_directory and os.path.isfile(os.path.join(config_directory, "input.txt")):
-			f = open(os.path.join(config_directory, "input.txt"), "r")
+		if install_directory != config_directory and Path(config_directory / "input.txt").is_file():
+			f = Path(config_directory / "input.txt").open("r")
 			text = f.read()
 			f.close()
 			lines = text.splitlines()
 
-			f = open(os.path.join(config_directory, "input.txt"), "w")
+			f = Path(config_directory / "input.txt").open("w")
 			for line in lines:
 				line = line.strip()
 				if "rename-playlist" in line:
@@ -388,8 +388,8 @@ def database_migrate(
 					value.misc["replaygain_album_gain"] = value.album_gain
 				del value.album_gain
 
-		if install_directory != config_directory and os.path.isfile(os.path.join(config_directory, "input.txt")):
-			with open(os.path.join(config_directory, "input.txt"), "a") as f:
+		if install_directory != config_directory and Path(config_directory / "input.txt").is_file():
+			with Path(config_directory / "input.txt").open("a") as f:
 				f.write("toggle-right-panel MB5\n")
 				f.write("toggle-gallery MB4\n")
 
@@ -402,8 +402,8 @@ def database_migrate(
 	if db_version <= 57:
 		logging.info("Updating database to version 58")
 
-		if install_directory != config_directory and os.path.isfile(os.path.join(config_directory, "input.txt")):
-			with open(os.path.join(config_directory, "input.txt"), "a") as f:
+		if install_directory != config_directory and Path(config_directory / "input.txt").is_file():
+			with Path(config_directory / "input.txt").open("a") as f:
 				f.write("\nregenerate-playlist R Alt\n")
 				f.write("clear-queue Q Shift Alt\n")
 				f.write("resize-window-16:9 F11 Alt\n")
@@ -412,8 +412,8 @@ def database_migrate(
 	if db_version <= 58:
 		logging.info("Updating database to version 59")
 
-		if install_directory != config_directory and os.path.isfile(os.path.join(config_directory, "input.txt")):
-			with open(os.path.join(config_directory, "input.txt"), "a") as f:
+		if install_directory != config_directory and Path(config_directory / "input.txt").is_file():
+			with Path(config_directory / "input.txt").open("a") as f:
 				f.write("\nrandom-album ; Alt\n")
 
 	if db_version <= 59:
@@ -439,8 +439,8 @@ def database_migrate(
 	if db_version <= 61:
 		logging.info("Updating database to version 62")
 
-		if install_directory != config_directory and os.path.isfile(os.path.join(config_directory, "input.txt")):
-			with open(os.path.join(config_directory, "input.txt"), "a") as f:
+		if install_directory != config_directory and Path(config_directory / "input.txt").is_file():
+			with Path(config_directory / "input.txt").open("a") as f:
 				f.write("\ntransfer-playtime-to P Ctrl Shift\n")
 
 	if db_version <= 62:
@@ -449,10 +449,10 @@ def database_migrate(
 			if item[0] == "T":
 				item[0] = "#"
 
-		if install_directory != config_directory and os.path.isfile(os.path.join(config_directory, "input.txt")):
-			with open(os.path.join(config_directory, "input.txt"), "r") as f:
+		if install_directory != config_directory and Path(config_directory / "input.txt").is_file():
+			with Path(config_directory / "input.txt").open("r") as f:
 				lines = f.readlines()
-			with open(os.path.join(config_directory, "input.txt"), "w") as f:
+			with Path(config_directory / "input.txt").open("w") as f:
 				for line in lines:
 					if line == "vol-up Up Shift\n" or line == "vol-down Down Shift\n":
 						continue
@@ -473,16 +473,16 @@ def database_migrate(
 	if db_version <= 64:
 		logging.info("Updating database to version 65")
 
-		if install_directory != config_directory and os.path.isfile(os.path.join(config_directory, "input.txt")):
-			with open(os.path.join(config_directory, "input.txt"), "a") as f:
+		if install_directory != config_directory and Path(config_directory / "input.txt").is_file():
+			with Path(config_directory / "input.txt").open("a") as f:
 				f.write("\nescape Escape\n")
 				f.write("toggle-mute M Ctrl\n")
 
 	if db_version <= 65:
 		logging.info("Updating database to version 66")
 
-		if install_directory != config_directory and os.path.isfile(os.path.join(config_directory, "input.txt")):
-			with open(os.path.join(config_directory, "input.txt"), "a") as f:
+		if install_directory != config_directory and Path(config_directory / "input.txt").is_file():
+			with Path(config_directory / "input.txt").open("a") as f:
 				f.write("\ntoggle-artistinfo O Ctrl\n")
 				f.write("cycle-theme ] Ctrl\n")
 				f.write("cycle-theme-reverse [ Ctrl\n")

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -488,7 +488,7 @@ if install_directory.startswith("/usr/"):
 
 # Set data folders (portable mode)
 user_directory = install_directory
-config_directory = user_directory
+config_directory = Path(user_directory)
 cache_directory = Path(user_directory) / "cache"
 home_directory = os.path.join(os.path.expanduser("~"))
 
@@ -537,13 +537,13 @@ if install_directory.startswith(("/opt/", "/usr/", "/app/", "/snap/")):
 if (install_mode and system == "Linux") or macos or msys:
 
 	cache_directory  = Path(GLib.get_user_cache_dir()) / "TauonMusicBox"
-	user_directory   = Path(GLib.get_user_data_dir())  / "TauonMusicBox"
-	config_directory = Path(GLib.get_user_data_dir())  / "TauonMusicBox"
+	user_directory   = str(Path(GLib.get_user_data_dir()) / "TauonMusicBox")
+	config_directory = Path(GLib.get_user_data_dir()) / "TauonMusicBox"
 
-	if not Path(user_directory).is_dir():
+	if not user_directory.is_dir():
 		os.makedirs(user_directory)
 
-	if not Path(config_directory).is_dir():
+	if not config_directory.is_dir():
 		os.makedirs(config_directory)
 
 	if snap_mode:
@@ -576,7 +576,7 @@ else:
 	logging.info("Running in portable mode")
 
 	user_directory = str(Path(install_directory) / "user-data")
-	config_directory = user_directory
+	config_directory = Path(user_directory)
 
 	if not Path(user_directory).is_dir():
 		os.makedirs(user_directory)
@@ -591,7 +591,7 @@ e_cache_dir = str(cache_directory / "export")
 g_cache_dir = str(cache_directory / "gallery")
 a_cache_dir = str(cache_directory / "artist")
 r_cache_dir = str(cache_directory / "radio-thumbs")
-b_cache_dir = str(Path(user_directory)  / "artist-backgrounds")
+b_cache_dir = str(Path(user_directory) / "artist-backgrounds")
 
 if not os.path.isdir(n_cache_dir):
 	os.makedirs(n_cache_dir)
@@ -847,7 +847,7 @@ if maximized:
 # loading_image.render(window_size[0] // 2 - loading_image.w // 2, window_size[1] // 2 - loading_image.h // 2)
 # SDL_RenderPresent(renderer)
 
-if install_directory != config_directory and not Path(Path(config_directory) / "input.txt").is_file():
+if install_directory != config_directory and not Path(config_directory / "input.txt").is_file():
 	logging.warning("Input config file is missing, first run? Copying input.txt template from templates directory")
 	#logging.warning(install_directory)
 	#logging.warning(config_directory)
@@ -1390,8 +1390,8 @@ class Prefs:
 		self.show_side_art = True
 		self.always_pin_playlists = True
 
-		self.user_directory = user_directory
-		self.cache_directory = cache_directory
+		self.user_directory:   str = user_directory
+		self.cache_directory: Path = cache_directory
 
 		self.window_opacity = window_opacity
 		self.gallery_single_click = True
@@ -2406,8 +2406,8 @@ class KeyMap:
 
 	def load(self):
 
-		path = os.path.join(config_directory, "input.txt")
-		with open(path, encoding="utf_8") as f:
+		path = config_directory / "input.txt"
+		with path.open(encoding="utf_8") as f:
 			content = f.read().splitlines()
 			for p in content:
 				if len(p) == 0 or len(p) > 100:
@@ -3712,15 +3712,15 @@ def save_prefs():
 	cf.update_value("chart-font", prefs.chart_font)
 	cf.update_value("chart-sorts-top-played", prefs.topchart_sorts_played)
 
-	if os.path.isdir(config_directory):
-		cf.dump(os.path.join(config_directory, "tauon.conf"))
+	if config_directory.is_dir():
+		cf.dump(str(config_directory / "tauon.conf"))
 	else:
 		logging.error("Missing config directory")
 
 
 def load_prefs():
 	cf.reset()
-	cf.load(os.path.join(config_directory, "tauon.conf"))
+	cf.load(str(config_directory / "tauon.conf"))
 
 	cf.add_comment("Tauon Music Box configuration file")
 	cf.br()
@@ -19917,7 +19917,7 @@ def reload_config_file():
 
 def open_config_file():
     save_prefs()
-    target = os.path.join(config_directory, "tauon.conf")
+    target = str(config_directory / "tauon.conf")
     if system == "Windows" or msys:
         os.startfile(target)
     elif macos:
@@ -19931,7 +19931,7 @@ def open_config_file():
 
 
 def open_keymap_file():
-    target = os.path.join(config_directory, "input.txt")
+    target = str(config_directory / "input.txt")
 
     if not os.path.isfile(target):
         show_message(_("Input file missing"))


### PR DESCRIPTION
```Python
	user_directory   = Path(GLib.get_user_data_dir())  / "TauonMusicBox"
	config_directory = Path(GLib.get_user_data_dir())  / "TauonMusicBox"
```

This was wrong and should have been string, only ran into it on the regular OS install and not the venv build.

user_directory is now string again for now, and config_directory was converted proper.