### PR TITLE
Main: Remove duplicated code causing issues

### DIFF
--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -479,13 +479,6 @@ try:
 except Exception:
 	logging.exception("Error accessing GTK settings")
 
-# if system == "Windows" or msys:
-#	 os.environ["PYSDL2_DLL_PATH"] = install_directory + "\\lib"
-
-# Assume that it's a classic Linux install, use standard paths
-if install_directory.startswith("/usr/"):
-	install_directory = "/usr/share/TauonMusicBox"
-
 # Set data folders (portable mode)
 user_directory = install_directory
 config_directory = Path(user_directory)


### PR DESCRIPTION
This is already done in `tauon.py`, so fixing the bug there was not enough... just remove it from main.

It looks like the original PR adding it made sense, but it was added to Holder later and de-dupe was missed.