### PR TITLE
Chromecast fixups, run.sh dirty venv mode, typing, enable warnings module and fix closing file handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Changelog
 - **Fixed** infinite timeouts in requests module, this should fix random rare freezes of various functionality related to networking
 - **Fixed** not checking for errors when using subprocess, this allowed various things to fail and continue going on as if nothing happened
 - **Fixed** saving files with forbidden characters from one FS to another that is FAT32, they are now replaced by an underscore on failure detection
-- **Fixed** leaking file handlers when handling themes and databases
+- **Fixed** leaking file handlers when handling themes and databases, this may fix potential memory leaks
 - **Updated** HTTP URLs to HTTPS where it was possible
 - ***Removed*** guitar chords feature - api.guitarchords.com it partially relied on is dead and this feature was unmaintained
 - **Improved** missing assets or locales now throw an error instead of silently (or not so silently) failing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Changelog
 - **Fixed** infinite timeouts in requests module, this should fix random rare freezes of various functionality related to networking
 - **Fixed** not checking for errors when using subprocess, this allowed various things to fail and continue going on as if nothing happened
 - **Fixed** saving files with forbidden characters from one FS to another that is FAT32, they are now replaced by an underscore on failure detection
+- **Fixed** leaking file handlers when handling themes and databases
 - **Updated** HTTP URLs to HTTPS where it was possible
 - ***Removed*** guitar chords feature - api.guitarchords.com it partially relied on is dead and this feature was unmaintained
 - **Improved** missing assets or locales now throw an error instead of silently (or not so silently) failing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Changelog
 - **Added** Ruff for a linter and support for Pyright (LSP) to make development easier
 - **Added** CI job to verify translations still compile, catches when people happen to submit broken translation PRs
 - **Fixed** always finding a tag even when one did not exist due to misusing a variable as both an integer and a boolean
+- **Fixed** crashes related to PipeWire [#1250](https://github.com/Taiko2k/Tauon/issues/1250)
+- **Fixed** audio cutting out on the PipeWire backend with specific custom quantum settings [#1245](https://github.com/Taiko2k/Tauon/issues/1245)
+- **Fixed** wrong encoding used for some tags in XSPF exports [#1331](https://github.com/Taiko2k/Tauon/issues/1331)
 - **Fixed** gensokyoradio.net radio fallback URL
 - **Fixed** mishandling SDL display change event, this fixes the "Grr" errors in the log
 - **Fixed** not defining GTK and Gdk version causing autoloading of 4.0 which we cannot support at the moment, now hardcoded to 3.0
@@ -19,7 +22,7 @@ Changelog
 - **Fixed** saving files with forbidden characters from one FS to another that is FAT32, they are now replaced by an underscore on failure detection
 - **Fixed** leaking file handlers when handling themes and databases, this may fix potential memory leaks
 - **Updated** HTTP URLs to HTTPS where it was possible
-- ***Removed*** guitar chords feature - api.guitarchords.com it partially relied on is dead and this feature was unmaintained
+- ***Removed*** guitar chords feature - api.guitarchords.com it partially relied on is dead, replaced by newer API that would need implementing, and the chords feature was unmaintained
 - **Improved** missing assets or locales now throw an error instead of silently (or not so silently) failing
 - **Improved** creating SDL window and renderer, making Tauon crash immediately on a fatal failure rather on nonsense errors later on
 - **Improved** build system

--- a/run.sh
+++ b/run.sh
@@ -47,6 +47,17 @@ win_build() {
 	cp TaskbarLib.tlb dist/tauon/ || echo 'TLB is not present!'
 }
 
+dirty_venv_run() {
+	if ! command -v python; then
+		echo -e "python executable not found? Is python installed? Debian(-based) distributions may need python-is-python3 installed via apt."
+		exit 1
+	fi
+	# Ensure correct cwd, for example: ~/Projects/Tauon
+	cd "$(dirname "${0}")"
+	export PYTHONPATH=".":"${PYTHONPATH-}"
+	source .venv/bin/activate
+	tauonmb # "${@}" # Passing args is broken atm
+}
 
 clean_venv_run() {
 	if ! command -v python; then
@@ -117,11 +128,13 @@ process_answer() {
 	case "${answer}" in
 		"Clean venv run,1" | "1" ) # TODO(Martin): restore ability to pass args if necessary
 			clean_venv_run; exit ;;
-		"Windows build,2" | "2" )
+		"Dirty venv run,2" | "2" )
+			dirty_venv_run; exit ;;
+		"Windows build,3" | "3" )
 			win_build; exit ;;
-		"Compile phazor,3" | "3" )
+		"Compile phazor,4" | "4" )
 			compile_phazor; exit ;;
-		"Compile phazor with PipeWire support,4" | "4" )
+		"Compile phazor with PipeWire support,5" | "5" )
 			compile_phazor_pipewire; exit ;;
 		* )
 			echo "Wrong option supplied! Options were: "
@@ -134,7 +147,13 @@ process_answer() {
 	esac
 }
 
-answer_options=("Clean venv run" "Windows build" "Compile phazor" "Compile phazor with PipeWire support")
+answer_options=(
+	"Clean venv run"
+	"Dirty venv run"
+	"Windows build"
+	"Compile phazor"
+	"Compile phazor with PipeWire support")
+
 if [[ ${#} -eq 0 ]]; then
 	show_menu
 else

--- a/src/tauon/__main__.py
+++ b/src/tauon/__main__.py
@@ -128,14 +128,15 @@ logging.basicConfig(
 logging.getLogger().handlers[0].setLevel(logging.DEBUG)
 logging.getLogger().handlers[0].setFormatter(CustomLoggingFormatter())
 
-if sys.platform != "win32":
-	import fcntl
-
 # https://docs.python.org/3/library/warnings.html
+logging.captureWarnings(capture=True)
 if not sys.warnoptions:
 	import warnings
 	warnings.simplefilter("default")
 	os.environ["PYTHONWARNINGS"] = "default" # Also affect subprocesses
+
+if sys.platform != "win32":
+	import fcntl
 
 n_version = "7.9.0"
 t_version = "v" + n_version

--- a/src/tauon/__main__.py
+++ b/src/tauon/__main__.py
@@ -131,6 +131,12 @@ logging.getLogger().handlers[0].setFormatter(CustomLoggingFormatter())
 if sys.platform != "win32":
 	import fcntl
 
+# https://docs.python.org/3/library/warnings.html
+if not sys.warnoptions:
+	import warnings
+	warnings.simplefilter("default")
+	os.environ["PYTHONWARNINGS"] = "default" # Also affect subprocesses
+
 n_version = "7.9.0"
 t_version = "v" + n_version
 t_title = "Tauon"

--- a/src/tauon/t_modules/t_chrome.py
+++ b/src/tauon/t_modules/t_chrome.py
@@ -9,6 +9,9 @@ import pychromecast
 from tauon.t_modules.t_extra import shooter
 
 if TYPE_CHECKING:
+	from pychromecast import Chromecast
+	from pychromecast.models import CastInfo
+
 	from tauon.t_modules.t_main import Tauon
 
 def get_ip() -> str:
@@ -28,13 +31,11 @@ def get_ip() -> str:
 
 class Chrome:
 	def __init__(self, tauon: Tauon) -> None:
-		self.tauon = tauon
-		self.services = []
-		self.active = False
-		self.cast = None
-		self.target_playlist = None
-		self.target_id = None
-		self.save_vol = 100
+		self.tauon:             Tauon = tauon
+		self.services: list[CastInfo] = []
+		self.active:             bool = False
+		self.cast:  Chromecast | None = None
+		self.save_vol:          float = 100
 
 	def rescan(self) -> None:
 		logging.info("Scanning for chromecasts...")

--- a/src/tauon/t_modules/t_chrome.py
+++ b/src/tauon/t_modules/t_chrome.py
@@ -102,7 +102,7 @@ class Chrome:
 			logging.critical("self.cast was None, this should not happen!")
 			return
 		self.cast.wait()
-		tr = self.tauon.pctl.g(track_id)
+		tr = self.tauon.pctl.get_track(track_id)
 		n = 0
 		try:
 			n = int(tr.track_number)

--- a/src/tauon/t_modules/t_chrome.py
+++ b/src/tauon/t_modules/t_chrome.py
@@ -149,11 +149,11 @@ class Chrome:
 			return
 		self.cast.media_controller.pause()
 
-	def seek(self, t: str) -> None:
+	def seek(self, position: float) -> None:
 		if self.cast is None:
 			logging.critical("self.cast was None, this should not happen!")
 			return
-		self.cast.media_controller.seek(t)
+		self.cast.media_controller.seek(position)
 
 	def volume(self, decimal: int) -> None:
 		if self.cast is None:

--- a/src/tauon/t_modules/t_chrome.py
+++ b/src/tauon/t_modules/t_chrome.py
@@ -46,6 +46,9 @@ class Chrome:
 				services, browser = pychromecast.discovery.discover_chromecasts()
 				pychromecast.discovery.stop_discovery(browser)
 				menu = self.tauon.chrome_menu
+				if menu is None:
+					logging.critical("menu was None, this should not happen!")
+					return
 				MenuItem = self.tauon.MenuItem
 
 				#menu.items.clear()
@@ -85,6 +88,9 @@ class Chrome:
 
 
 	def update(self) -> tuple:
+		if self.cast is None:
+			logging.critical("self.cast was None, this should not happen!")
+			return ()
 		self.cast.media_controller.update_status()
 		return self.cast.media_controller.status.current_time, \
 			self.cast.media_controller.status.media_custom_data.get("id"), \
@@ -92,6 +98,9 @@ class Chrome:
 			self.cast.media_controller.status.duration
 
 	def start(self, track_id: int, enqueue: bool = False, t: int = 0, url: str | None = None) -> None:
+		if self.cast is None:
+			logging.critical("self.cast was None, this should not happen!")
+			return
 		self.cast.wait()
 		tr = self.tauon.pctl.g(track_id)
 		n = 0
@@ -123,18 +132,33 @@ class Chrome:
 		self.cast.media_controller.play_media(url, "audio/mpeg", media_info=m, metadata=d, current_time=t, enqueue=enqueue)
 
 	def stop(self) -> None:
+		if self.cast is None:
+			logging.critical("self.cast was None, this should not happen!")
+			return
 		self.cast.media_controller.stop()
 
 	def play(self) -> None:
+		if self.cast is None:
+			logging.critical("self.cast was None, this should not happen!")
+			return
 		self.cast.media_controller.play()
 
 	def pause(self) -> None:
+		if self.cast is None:
+			logging.critical("self.cast was None, this should not happen!")
+			return
 		self.cast.media_controller.pause()
 
 	def seek(self, t: str) -> None:
+		if self.cast is None:
+			logging.critical("self.cast was None, this should not happen!")
+			return
 		self.cast.media_controller.seek(t)
 
 	def volume(self, decimal: int) -> None:
+		if self.cast is None:
+			logging.critical("self.cast was None, this should not happen!")
+			return
 		self.cast.set_volume(decimal)
 
 	def end(self) -> None:

--- a/src/tauon/t_modules/t_chrome.py
+++ b/src/tauon/t_modules/t_chrome.py
@@ -44,7 +44,7 @@ class Chrome:
 			try:
 				#self.tauon.gui.show_message(self.tauon.strings.scan_chrome)
 				services, browser = pychromecast.discovery.discover_chromecasts()
-				pychromecast.discovery.stop_discovery(browser)
+				browser.stop_discovery()
 				menu = self.tauon.chrome_menu
 				if menu is None:
 					logging.critical("menu was None, this should not happen!")

--- a/src/tauon/t_modules/t_chrome.py
+++ b/src/tauon/t_modules/t_chrome.py
@@ -20,13 +20,13 @@ def get_ip() -> str:
 	try:
 		# doesn't even have to be reachable
 		s.connect(("10.255.255.255", 1))
-		IP = s.getsockname()[0]
+		IPv4 = s.getsockname()[0]
 	except Exception:
 		logging.exception("Failed to get socket name.")
-		IP = "127.0.0.1"
+		IPv4 = "127.0.0.1"
 	finally:
 		s.close()
-	return IP
+	return IPv4
 
 
 class Chrome:

--- a/src/tauon/t_modules/t_jellyfin.py
+++ b/src/tauon/t_modules/t_jellyfin.py
@@ -193,7 +193,7 @@ class Jellyfin:
 
 		ids = []
 		for t in self.pctl.multi_playlist[pl].playlist_ids:
-			track = self.pctl.g(t)
+			track = self.pctl.get_track(t)
 			if track.url_key not in ids and track.file_ext == "JELY":
 				ids.append(track.url_key)
 
@@ -444,7 +444,7 @@ class Jellyfin:
 				#logging.info(track.items())
 				if replace_existing:
 					track_id = existing_track
-					nt = self.pctl.g(track_id)
+					nt = self.pctl.get_track(track_id)
 				else:
 					nt = self.tauon.TrackClass()
 				nt.index = track_id  # this is tauons track id

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -43252,7 +43252,7 @@ pref_box.themes.append((ColoursClass(), "Mindaro", 0))
 theme_files = get_themes()
 for i, theme in enumerate(theme_files):
 	c = ColoursClass()
-	load_theme(c, theme[0])
+	load_theme(c, Path(theme[0]))
 	pref_box.themes.append((c, theme[1], i + 1))
 
 pctl.total_playtime = star_store.get_total()
@@ -44660,7 +44660,7 @@ while pctl.running:
 				colours.lm = False
 				colours.__init__()
 
-				load_theme(colours, theme_item[0])
+				load_theme(colours, Path(theme_item[0]))
 				deco.load(colours.deco)
 				logging.info("Applying theme: " + gui.theme_name)
 

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -3024,7 +3024,8 @@ if star_size1 == 0 and star_size2 == 0:
 	logging.warning("Star database file is missing, first run? Will create one anew!")
 else:
 	try:
-		star_store.db = pickle.load(to_load.open("rb"))
+		with to_load.open("rb") as file:
+			star_store.db = pickle.load(file)
 	except Exception:
 		logging.exception("Unknown error loading star.p file")
 
@@ -3032,7 +3033,8 @@ else:
 album_star_path = Path(user_directory) / "album-star.p"
 if album_star_path.is_file():
 	try:
-		album_star_store.db = pickle.load(album_star_path.open("rb"))
+		with album_star_path.open("rb") as file:
+			album_star_store.db = pickle.load(file)
 	except Exception:
 		logging.exception("Unknown error loading album-star.p file")
 else:
@@ -3114,23 +3116,21 @@ for t in range(2):
 		if t == 0:
 			if not state_path1.is_file():
 				continue
-			state_file = state_path1.open("rb")
+			with state_path1.open("rb") as file:
+				save = pickle.load(file)
 		if t == 1:
 			if not state_path2.is_file():
 				logging.warning("State database file is missing, first run? Will create one anew!")
 				break
-			state_file = state_path2.open("rb")
+			logging.warning("Loading backup state.p!")
+			with state_path2.open("rb") as file:
+				save = pickle.load(file)
 
 		# def tt():
 		#	 while True:
 		#		 logging.info(state_file.tell())
 		#		 time.sleep(0.01)
 		# shooter(tt)
-
-		save = pickle.load(state_file)
-
-		if t == 1:
-			logging.warning("Loading backup state.p!")
 
 		db_version = save[17]
 		if db_version != latest_db_version:
@@ -3501,7 +3501,6 @@ for t in range(2):
 		if save[182] is not None:
 			prefs.gallery_combine_disc = save[182]
 
-		state_file.close()
 		del save
 		break
 
@@ -4742,9 +4741,8 @@ def tag_scan(nt: TrackClass) -> TrackClass | None:
 				nt.title = "Track " + str(nt.subtrack + 1)
 
 		elif nt.file_ext in ("MOD", "IT", "XM", "S3M", "MPTM") and mpt:
-			f = open(nt.fullpath, "rb")
-			data = f.read()
-			f.close()
+			with Path(nt.fullpath).open("rb") as file:
+				data = file.read()
 			MOD1 = MOD.from_address(
 				mpt.openmpt_module_create_from_memory(
 					ctypes.c_char_p(data), ctypes.c_size_t(len(data)), None, None, None))
@@ -8888,14 +8886,12 @@ class Tauon:
 			f.seek(0)
 			z = zipfile.ZipFile(f, mode="r")
 			exe = z.open("ffmpeg-5.0.1-essentials_build/bin/ffmpeg.exe")
-			ff = open(os.path.join(user_directory, "ffmpeg.exe"), "wb")
-			ff.write(exe.read())
-			ff.close()
+			with (Path(user_directory) / "ffmpeg.exe").open("wb") as file:
+				file.write(exe.read())
 
 			exe = z.open("ffmpeg-5.0.1-essentials_build/bin/ffprobe.exe")
-			ff = open(os.path.join(user_directory, "ffprobe.exe"), "wb")
-			ff.write(exe.read())
-			ff.close()
+			with (Path(user_directory) / "ffprobe.exe").open("wb") as file:
+				file.write(exe.read())
 
 			exe.close()
 			show_message(_("FFMPEG fetch complete"), mode="done")
@@ -12988,9 +12984,8 @@ class AlbumArt:
 						response = urllib.request.urlopen(get_network_thumbnail_url(track), cafile=tauon.ca)
 						source_image = io.BytesIO(response.read())
 					if source_image:
-						f = open(cached_path, "wb")
-						f.write(source_image.read())
-						f.close()
+						with Path(cached_path).open("wb") as file:
+							file.write(source_image.read())
 						source_image.seek(0)
 
 			except Exception:
@@ -14087,9 +14082,8 @@ def load_m3u(path: str) -> None:
 	if not os.path.isfile(path):
 		return
 
-	f = open(path, encoding="utf-8")
-	lines = f.readlines()
-	f.close()
+	with Path(path).open(encoding="utf-8") as file:
+		lines = file.readlines()
 
 	for i, line in enumerate(lines):
 		line = line.strip("\r\n").strip()

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -42961,10 +42961,11 @@ def save_state() -> None:
 	]
 
 	try:
-		pickle.dump(save, open(user_directory + "/state.p.backup", "wb"), protocol=pickle.HIGHEST_PROTOCOL)
+		with (Path(user_directory) / "state.p.backup").open("wb") as file:
+			pickle.dump(save, file, protocol=pickle.HIGHEST_PROTOCOL)
 		# if not pctl.running:
-
-		pickle.dump(save, open(user_directory + "/state.p", "wb"), protocol=pickle.HIGHEST_PROTOCOL)
+		with (Path(user_directory) / "state.p").open("wb") as file:
+			pickle.dump(save, file, protocol=pickle.HIGHEST_PROTOCOL)
 
 		old_position = old_window_position
 		if not prefs.save_window_position:
@@ -42980,12 +42981,13 @@ def save_state() -> None:
 		]
 
 		if not fs_mode:
-			pickle.dump(save, open(user_directory + "/window.p", "wb"), protocol=pickle.HIGHEST_PROTOCOL)
+			with (Path(user_directory) / "window.p").open("wb") as file:
+				pickle.dump(save, file, protocol=pickle.HIGHEST_PROTOCOL)
 
 		spot_ctl.save_token()
 
-		with open(user_directory + "/lyrics_substitutions.json", "w") as f:
-			json.dump(prefs.lyrics_subs, f)
+		with (Path(user_directory) / "lyrics_substitutions.json").open("w") as file:
+			json.dump(prefs.lyrics_subs, file)
 
 		save_prefs()
 
@@ -48209,7 +48211,8 @@ while pctl.running:
 		try:
 			if should_save_state:
 				logging.info("Auto save playtime")
-				pickle.dump(star_store.db, open(user_directory + "/star.p", "wb"), protocol=pickle.HIGHEST_PROTOCOL)
+				with (Path(user_directory) / "star.p").open("wb") as file:
+					pickle.dump(star_store.db, file, protocol=pickle.HIGHEST_PROTOCOL)
 			else:
 				logging.info("Dev mode, skip auto saving playtime")
 		except PermissionError:
@@ -48259,16 +48262,20 @@ if prefs.reload_play_state and pctl.playing_state in (1, 2):
 	prefs.reload_state = (pctl.playing_state, pctl.playing_time)
 
 if should_save_state:
-	pickle.dump(star_store.db, open(user_directory + "/star.p", "wb"), protocol=pickle.HIGHEST_PROTOCOL)
-	pickle.dump(album_star_store.db, open(user_directory + "/album-star.p", "wb"), protocol=pickle.HIGHEST_PROTOCOL)
+	with (Path(user_directory) / "star.p").open("wb") as file:
+		pickle.dump(star_store.db, file, protocol=pickle.HIGHEST_PROTOCOL)
+	with (Path(user_directory) / "album-star.p").open("wb") as file:
+		pickle.dump(album_star_store.db, file, protocol=pickle.HIGHEST_PROTOCOL)
 
 gui.gallery_positions[pl_to_id(pctl.active_playlist_viewing)] = gui.album_scroll_px
 save_state()
 
 date = datetime.date.today()
 if should_save_state:
-	pickle.dump(star_store.db, open(user_directory + "/star.p.backup", "wb"), protocol=pickle.HIGHEST_PROTOCOL)
-	pickle.dump(star_store.db, open(user_directory + "/star.p.backup" + str(date.month), "wb"), protocol=pickle.HIGHEST_PROTOCOL)
+	with (Path(user_directory) / "star.p.backup").open("wb") as file:
+		pickle.dump(star_store.db, file, protocol=pickle.HIGHEST_PROTOCOL)
+	with (Path(user_directory) / f"star.p.backup{str(date.month)}").open("wb") as file:
+		pickle.dump(star_store.db, file, protocol=pickle.HIGHEST_PROTOCOL)
 
 if tauon.stream_proxy and tauon.stream_proxy.download_running:
 	logging.info("Stopping stream...")

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -5188,7 +5188,7 @@ class PlayerCtl:
 		self.pause_queue: bool = False
 		self.left_time = 0
 		self.left_index = 0
-		self.player_volume = volume
+		self.player_volume: float = volume
 		self.new_time = 0
 		self.time_to_get = []
 		self.a_time = 0
@@ -10721,7 +10721,7 @@ class TimedLyricsRen:
 		self.ready = True
 		return True
 
-	def render(self, index, x, y, side_panel=False, w=0, h=0):
+	def render(self, index: int, x: int, y: int, side_panel: bool = False, w: int = 0, h: int = 0) -> bool | None:
 
 		if index != self.index:
 			self.ready = False
@@ -10791,7 +10791,7 @@ class TimedLyricsRen:
 				yy += max(h - round(6 * gui.scale), spacing)
 			else:
 				yy += spacing
-
+		return None
 
 timed_lyrics_ren = TimedLyricsRen()
 
@@ -10922,7 +10922,7 @@ class TextBox2:
 
 	def __init__(self) -> None:
 
-		self.text = ""
+		self.text: str = ""
 		self.cursor_position = 0
 		self.selection = 0
 		self.offset = 0
@@ -10962,7 +10962,7 @@ class TextBox2:
 		self.selection = len(self.text)
 		self.cursor_position = 0
 
-	def eliminate_selection(self):
+	def eliminate_selection(self) -> None:
 		if self.selection != self.cursor_position:
 			if self.selection > self.cursor_position:
 				self.text = self.text[0: len(self.text) - self.selection] + self.text[len(self.text) - self.cursor_position:]
@@ -10971,7 +10971,7 @@ class TextBox2:
 				self.text = self.text[0: len(self.text) - self.cursor_position] + self.text[len(self.text) - self.selection:]
 				self.cursor_position = self.selection
 
-	def get_selection(self, p: int = 1):
+	def get_selection(self, p: int = 1) -> str:
 		if self.selection != self.cursor_position:
 			if p == 1:
 				if self.selection > self.cursor_position:
@@ -14600,7 +14600,7 @@ def close_all_menus():
 	Menu.active = False
 
 
-def menu_standard_or_grey(bool):
+def menu_standard_or_grey(bool: bool):
 	if bool:
 		line_colour = colours.menu_text
 	else:
@@ -22099,7 +22099,7 @@ def gstreamer_test(_) -> bool:
 
 
 # Create top menu
-x_menu = Menu(190, show_icons=True)
+x_menu: Menu = Menu(190, show_icons=True)
 view_menu = Menu(170)
 set_menu = Menu(150)
 set_menu_hidden = Menu(100)
@@ -23232,7 +23232,7 @@ def import_popm():
 x_menu.add_to_sub(0, MenuItem(_("Import POPM Ratings"), import_popm))
 
 
-def clear_ratings():
+def clear_ratings() -> None:
 	if not key_shift_down:
 		show_message(
 			_("This will delete all track and album ratings from the local database!"),
@@ -23248,7 +23248,7 @@ def clear_ratings():
 x_menu.add_to_sub(0, MenuItem(_("Reset User Ratings"), clear_ratings))
 
 
-def find_incomplete():
+def find_incomplete() -> None:
 	gen_incomplete(pctl.active_playlist_viewing)
 
 
@@ -23263,10 +23263,10 @@ def cast_deco():
 	return [line_colour, colours.menu_background, None]
 
 
-def cast_search2():
+def cast_search2() -> None:
 	chrome.rescan()
 
-def cast_search():
+def cast_search() -> None:
 
 	if tauon.chrome_mode:
 		pctl.stop()
@@ -23288,7 +23288,7 @@ tauon.chrome_menu = x_menu
 #x_menu.add(_("Cast…"), cast_search, cast_deco)
 
 
-def clear_queue():
+def clear_queue() -> None:
 	pctl.force_queue = []
 	gui.pl_update = 1
 	pctl.pause_queue = False
@@ -23297,31 +23297,31 @@ def clear_queue():
 mode_menu = Menu(175)
 
 
-def set_mini_mode_A1():
+def set_mini_mode_A1() -> None:
 	prefs.mini_mode_mode = 0
 	set_mini_mode()
 
 
-def set_mini_mode_B1():
+def set_mini_mode_B1() -> None:
 	prefs.mini_mode_mode = 1
 	set_mini_mode()
 
 
-def set_mini_mode_A2():
+def set_mini_mode_A2() -> None:
 	prefs.mini_mode_mode = 2
 	set_mini_mode()
 
 
-def set_mini_mode_C1():
+def set_mini_mode_C1() -> None:
 	prefs.mini_mode_mode = 5
 	set_mini_mode()
 
-def set_mini_mode_B2():
+def set_mini_mode_B2() -> None:
 	prefs.mini_mode_mode = 3
 	set_mini_mode()
 
 
-def set_mini_mode_D():
+def set_mini_mode_D() -> None:
 	prefs.mini_mode_mode = 4
 	set_mini_mode()
 
@@ -23334,7 +23334,7 @@ mode_menu.add(MenuItem(_("Square"), set_mini_mode_B1))
 mode_menu.add(MenuItem(_("Square Large"), set_mini_mode_B2))
 
 
-def copy_bb_metadata():
+def copy_bb_metadata() -> str | None:
 	tr = pctl.playing_object()
 	if not tr.title and not tr.artist and pctl.playing_state == 3:
 		return pctl.tag_meta
@@ -23343,6 +23343,7 @@ def copy_bb_metadata():
 		copy_to_clipboard(text)
 	else:
 		show_message(_("No metadata available to copy"))
+	return None
 
 
 mode_menu.br()
@@ -23351,11 +23352,11 @@ mode_menu.add(MenuItem(_("Copy Title to Clipboard"), copy_bb_metadata))
 extra_menu = Menu(175, show_icons=True)
 
 
-def stop():
+def stop() -> None:
 	pctl.stop()
 
 
-def random_track():
+def random_track() -> None:
 	playlist = pctl.multi_playlist[pctl.active_playlist_playing].playlist_ids
 	if playlist:
 		random_position = random.randrange(0, len(playlist))
@@ -23367,7 +23368,7 @@ def random_track():
 extra_menu.add(MenuItem(_("Random Track"), random_track, hint=";"))
 
 
-def random_album():
+def random_album() -> None:
 	folders = {}
 	playlist = pctl.multi_playlist[pctl.active_playlist_playing].playlist_ids
 	if playlist:
@@ -23382,7 +23383,7 @@ def random_album():
 		pctl.show_current()
 
 
-def radio_random():
+def radio_random() -> None:
 	pctl.advance(rr=True)
 
 
@@ -23406,7 +23407,7 @@ extra_menu.add(MenuItem(_("Revert"), pctl.revert, hint="Shift+/", icon=revert_ic
 extra_menu.add(MenuItem(_("Clear Queue"), clear_queue, queue_deco, hint="Alt+Shift+Q"))
 
 
-def heart_menu_colour():
+def heart_menu_colour() -> list[int] | None:
 	if not (pctl.playing_state == 1 or pctl.playing_state == 2):
 		if colours.lm:
 			return [255, 150, 180, 255]

--- a/src/tauon/t_modules/t_phazor.py
+++ b/src/tauon/t_modules/t_phazor.py
@@ -450,7 +450,7 @@ def player4(tauon: Tauon) -> None:
 				logging.info("Precache next track")
 				next_track = pctl.advance(dry=True)
 				if next_track is not None:
-					self.dl_file(pctl.g(next_track))
+					self.dl_file(pctl.get_track(next_track))
 
 			self.trim_cache()
 			self.running = False
@@ -725,8 +725,8 @@ def player4(tauon: Tauon) -> None:
 	chrome_cool_timer = Timer()
 	chrome_mode = False
 
-	def chrome_start(track: TrackClass, enqueue: bool = False, t: int = 0) -> None:
-		track = pctl.g(track)
+	def chrome_start(track_id: int, enqueue: bool = False, t: int = 0) -> None:
+		track = pctl.get_track(track_id)
 		# if track.is_cue:
 		#	 logging.error("CUE cast not supported")
 		#	 return
@@ -765,7 +765,7 @@ def player4(tauon: Tauon) -> None:
 			break
 
 		# Level meter
-		if (state == 1 or state == 3) and gui.vis == 1:
+		if (state in (1, 3)) and gui.vis == 1:
 			amp = aud.get_level_peak_l()
 			l = amp * 12
 			amp = aud.get_level_peak_r()

--- a/src/tauon/t_modules/t_spot.py
+++ b/src/tauon/t_modules/t_spot.py
@@ -877,7 +877,7 @@ class SpotCtl:
 		l = self.append_album(url, return_list=True)
 		self.tauon.pctl.multi_playlist.append(
 			self.tauon.pl_gen(
-				title=f"{self.tauon.pctl.g(l[0]).artist} - {self.tauon.pctl.g(l[0]).album}",
+				title=f"{self.tauon.pctl.get_track(l[0]).artist} - {self.tauon.pctl.get_track(l[0]).album}",
 				playlist_ids=l,
 				hide_title=False),
 		)

--- a/src/tauon/t_modules/t_themeload.py
+++ b/src/tauon/t_modules/t_themeload.py
@@ -40,6 +40,7 @@ from sdl2.sdlimage import IMG_Load_RW
 from tauon.t_modules.t_extra import rgb_add_hls, test_lumi
 
 if TYPE_CHECKING:
+	from pathlib import Path
 	from tauon.t_modules.t_draw import TDraw
 	from tauon.t_modules.t_main import GuiVar, Tauon
 
@@ -88,247 +89,246 @@ def get_colour_from_line(cline: str) -> list[int]:
 	return colour
 
 
-def load_theme(colours: GuiVar, path: str) -> None:
+def load_theme(colours: GuiVar, path: Path) -> None:
 
-	f = open(path, encoding="utf-8")
-	content = f.readlines()
+	with path.open(encoding="utf-8") as f:
+		content = f.readlines()
+		for p in content:
+			p = p.strip()
+			if "# " in p:
+				p = p.split("# ")[0]
+			if not p:
+				continue
+			if p[0] == "#" and ("-" in p[:7] or " " in p[:7] or "\t" in p[:7]):
+				continue
+			if p.startswith("deco="):
+				colours.deco = p.split("=", 1)[1].strip()
+			if "light-mode" in p:
+				colours.light_mode()
+			if "window frame" in p:
+				colours.window_frame = get_colour_from_line(p)
+			if "gallery highlight" in p:
+				colours.gallery_highlight = get_colour_from_line(p)
+			if "index playing" in p:
+				colours.index_playing = get_colour_from_line(p)
+			if "time playing" in p:
+				colours.time_text = get_colour_from_line(p)
+			if "artist playing" in p:
+				colours.artist_playing = get_colour_from_line(p)
+			if "album line" in p:  # Bad name
+				colours.album_text = get_colour_from_line(p)
+			if "track album" in p:
+				colours.album_text = get_colour_from_line(p)
+			if "album playing" in p:
+				colours.album_playing = get_colour_from_line(p)
+			if "top panel" in p or "player background" in p:
+				colours.top_panel_background = get_colour_from_line(p)
 
-	for p in content:
-		p = p.strip()
-		if "# " in p:
-			p = p.split("# ")[0]
-		if not p:
-			continue
-		if p[0] == "#" and ("-" in p[:7] or " " in p[:7] or "\t" in p[:7]):
-			continue
-		if p.startswith("deco="):
-			colours.deco = p.split("=", 1)[1].strip()
-		if "light-mode" in p:
+				colours.status_text_over = rgb_add_hls(colours.top_panel_background, 0, 0.83, 0)
+				colours.status_text_normal = rgb_add_hls(colours.top_panel_background, 0, 0.30, -0.15)
+
+				if test_lumi(colours.bottom_panel_colour) < 0.2:
+					colours.corner_icon = [0, 0, 0, 60]
+				elif test_lumi(colours.bottom_panel_colour) < 0.8:
+					colours.corner_icon = [40, 40, 40, 255]
+				else:
+					colours.corner_icon = [255, 255, 255, 30]
+
+				if test_lumi(colours.bottom_panel_colour) < 0.2:
+					colours.corner_icon = [0, 0, 0, 60]
+
+				if not colours.lm:
+					colours.corner_button = rgb_add_hls(colours.top_panel_background, 0, 0.18, 0)
+
+			if "corner button off" in p:
+				colours.corner_button = get_colour_from_line(p)
+			if "corner button on" in p:
+				colours.corner_button_active = get_colour_from_line(p)
+			if "menu button normal" in p:
+				colours.status_text_normal = get_colour_from_line(p)
+			if "menu button hover" in p:
+				colours.status_text_over = get_colour_from_line(p)
+			if "queue panel" in p:
+				colours.queue_background = get_colour_from_line(p)
+			if "side panel" in p:
+				colours.side_panel_background = get_colour_from_line(p)
+				colours.playlist_box_background = colours.side_panel_background
+			if "gallery background" in p:
+				colours.gallery_background = get_colour_from_line(p)
+			if "playlist panel" in p:  # bad name
+				colours.playlist_panel_background = get_colour_from_line(p)
+			if "tracklist panel" in p:
+				colours.playlist_panel_background = get_colour_from_line(p)
+			if "track line" in p:
+				colours.title_text = get_colour_from_line(p)
+			if "track missing" in p:
+				colours.playlist_text_missing = get_colour_from_line(p)
+			if "playing highlight" in p:
+				colours.row_playing_highlight = get_colour_from_line(p)
+			if "track time" in p:
+				colours.bar_time = get_colour_from_line(p)
+			if "fav line" in p:
+				colours.star_line = get_colour_from_line(p)
+			if "folder title" in p:
+				colours.folder_title = get_colour_from_line(p)
+			if "folder line" in p:
+				colours.folder_line = get_colour_from_line(p)
+			if "buttons off" in p:
+				colours.media_buttons_off = get_colour_from_line(p)
+			if "buttons over" in p:
+				colours.media_buttons_over = get_colour_from_line(p)
+			if "buttons active" in p:
+				colours.media_buttons_active = get_colour_from_line(p)
+			if "playing time" in p:
+				colours.time_playing = get_colour_from_line(p)
+			if "track index" in p:
+				colours.index_text = get_colour_from_line(p)
+			if "track playing" in p:
+				colours.title_playing = get_colour_from_line(p)
+			if "select highlight" in p:
+				colours.row_select_highlight = get_colour_from_line(p)
+			if "track artist" in p:
+				colours.artist_text = get_colour_from_line(p)
+			if "tab active line" in p:  # bad name
+				colours.tab_text_active = get_colour_from_line(p)
+			if "tab line" in p:  # bad name
+				colours.tab_text = get_colour_from_line(p)
+			if "tab active text" in p:
+				colours.tab_text_active = get_colour_from_line(p)
+			if "tab text" in p:
+				colours.tab_text = get_colour_from_line(p)
+			if "tab background" in p:
+				colours.tab_background = get_colour_from_line(p)
+			if "tab over" in p:
+				colours.tab_highlight = get_colour_from_line(p)
+			if "tab active background" in p:
+				colours.tab_background_active = get_colour_from_line(p)
+			if "title info" in p:
+				colours.side_bar_line1 = get_colour_from_line(p)
+			if "extra info" in p:
+				colours.side_bar_line2 = get_colour_from_line(p)
+			if "bottom title" in p:
+				colours.bar_title_text = get_colour_from_line(p)
+			if "scroll bar" in p:
+				colours.scroll_colour = get_colour_from_line(p)
+			if "seek bar" in p:
+				colours.seek_bar_fill = get_colour_from_line(p)
+			if "seek bg" in p:
+				colours.seek_bar_background = get_colour_from_line(p)
+			if "volume bar" in p:
+				colours.volume_bar_fill = get_colour_from_line(p)
+			if "volume bg" in p:
+				colours.volume_bar_background = get_colour_from_line(p)
+			if "mode off" in p:
+				colours.mode_button_off = get_colour_from_line(p)
+			if "mode over" in p:
+				colours.mode_button_over = get_colour_from_line(p)
+			if "mode on" in p:
+				colours.mode_button_active = get_colour_from_line(p)
+			if "art border" in p:
+				colours.art_box = get_colour_from_line(p)
+			if "tb line" in p:
+				colours.tb_line = get_colour_from_line(p)
+			if "music vis" in p:
+				colours.vis_colour = get_colour_from_line(p)
+			if "menu background" in p:
+				colours.menu_background = get_colour_from_line(p)
+			if "menu text" in p:
+				colours.menu_text = get_colour_from_line(p)
+			if "menu disable" in p:
+				colours.menu_text_disabled = get_colour_from_line(p)
+			if "menu icons" in p:
+				colours.menu_icons = get_colour_from_line(p)
+			if "menu highlight" in p:
+				colours.menu_highlight_background = get_colour_from_line(p)
+			if "menu border" in p:
+				colours.menu_tab = get_colour_from_line(p)
+			if "lyrics showcase" in p:
+				colours.lyrics = get_colour_from_line(p)
+			if "bottom panel" in p:
+				colours.bottom_panel_colour = get_colour_from_line(p)
+				# colours.menu_background = colours.bottom_panel_colour
+			if "mini bg" in p:
+				colours.mini_mode_background = get_colour_from_line(p)
+			if "mini border" in p:
+				colours.mini_mode_border = get_colour_from_line(p)
+			if "mini text 1" in p:
+				colours.mini_mode_text_1 = get_colour_from_line(p)
+			if "mini text 2" in p:
+				colours.mini_mode_text_2 = get_colour_from_line(p)
+			if "column-" in p:
+				key = p[p.find("column-") + 7:].replace("-", " ").lower().title().rstrip()
+				value = get_colour_from_line(p)
+				colours.column_colours[key] = value
+			if "column+" in p:
+				key = p[p.find("column+") + 7:].replace("-", " ").lower().title().rstrip()
+				value = get_colour_from_line(p)
+				colours.column_colours_playing[key] = value
+			if "menu bg" in p:
+				colours.menu_background = get_colour_from_line(p)
+			if "playlist box bg" in p:  # bad name
+				colours.playlist_box_background = get_colour_from_line(p)
+			if "playlist background" in p:
+				colours.playlist_box_background = get_colour_from_line(p)
+
+			if "box background" in p:
+				colours.box_background = get_colour_from_line(p)
+			if "box border" in p:
+				colours.box_border = get_colour_from_line(p)
+			if "box text border" in p:
+				colours.box_text_border = get_colour_from_line(p)
+			if "box text label" in p:
+				colours.box_text_label = get_colour_from_line(p)
+
+			if "box title text" in p:
+				colours.box_title_text = get_colour_from_line(p)
+			if "box text normal" in p:
+				colours.box_text = get_colour_from_line(p)
+			if "box sub text" in p:
+				colours.box_sub_text = get_colour_from_line(p)
+			if "box input text" in p:
+				colours.box_input_text = get_colour_from_line(p)
+
+			if "box button text highlight" in p:
+				colours.box_button_text_highlight = get_colour_from_line(p)
+			if "box button text normal" in p:
+				colours.box_button_text = get_colour_from_line(p)
+			if "box button background normal" in p:
+				colours.box_button_background = get_colour_from_line(p)
+			if "box button background highlight" in p:
+				colours.box_button_background_highlight = get_colour_from_line(p)
+			if "box button border" in p:
+				colours.box_check_border = get_colour_from_line(p)
+
+			if "window buttons background" in p:
+				colours.window_buttons_bg = get_colour_from_line(p)
+			if "window buttons on" in p:
+				colours.window_buttons_bg_over = get_colour_from_line(p)
+			if "window buttons icon off" in p:
+				colours.window_button_icon_off = get_colour_from_line(p)
+				colours.window_button_x_off = colours.window_button_icon_off
+			if "window buttons icon over" in p:
+				colours.window_buttons_icon_over = get_colour_from_line(p)
+				colours.window_button_x_on = colours.window_buttons_icon_over
+			if "window button x on" in p:
+				colours.window_button_x_on = get_colour_from_line(p)
+			if "window button x off" in p:
+				colours.window_button_x_off = get_colour_from_line(p)
+			if "column bar background" in p:
+				colours.column_bar_background = get_colour_from_line(p)
+
+			if "artist bio background" in p:
+				colours.artist_bio_background = get_colour_from_line(p)
+			if "artist bio text" in p:
+				colours.artist_bio_text = get_colour_from_line(p)
+			# if "panel button off" in p:
+			#	 colours.corner_button = get_colour_from_line(p)
+			# if "panel button on" in p:
+			#	 colours.corner_button_active = get_colour_from_line(p)
+
+		colours.post_config()
+		if colours.lm:
 			colours.light_mode()
-		if "window frame" in p:
-			colours.window_frame = get_colour_from_line(p)
-		if "gallery highlight" in p:
-			colours.gallery_highlight = get_colour_from_line(p)
-		if "index playing" in p:
-			colours.index_playing = get_colour_from_line(p)
-		if "time playing" in p:
-			colours.time_text = get_colour_from_line(p)
-		if "artist playing" in p:
-			colours.artist_playing = get_colour_from_line(p)
-		if "album line" in p:  # Bad name
-			colours.album_text = get_colour_from_line(p)
-		if "track album" in p:
-			colours.album_text = get_colour_from_line(p)
-		if "album playing" in p:
-			colours.album_playing = get_colour_from_line(p)
-		if "top panel" in p or "player background" in p:
-			colours.top_panel_background = get_colour_from_line(p)
-
-			colours.status_text_over = rgb_add_hls(colours.top_panel_background, 0, 0.83, 0)
-			colours.status_text_normal = rgb_add_hls(colours.top_panel_background, 0, 0.30, -0.15)
-
-			if test_lumi(colours.bottom_panel_colour) < 0.2:
-				colours.corner_icon = [0, 0, 0, 60]
-			elif test_lumi(colours.bottom_panel_colour) < 0.8:
-				colours.corner_icon = [40, 40, 40, 255]
-			else:
-				colours.corner_icon = [255, 255, 255, 30]
-
-			if test_lumi(colours.bottom_panel_colour) < 0.2:
-				colours.corner_icon = [0, 0, 0, 60]
-
-			if not colours.lm:
-				colours.corner_button = rgb_add_hls(colours.top_panel_background, 0, 0.18, 0)
-
-		if "corner button off" in p:
-			colours.corner_button = get_colour_from_line(p)
-		if "corner button on" in p:
-			colours.corner_button_active = get_colour_from_line(p)
-		if "menu button normal" in p:
-			colours.status_text_normal = get_colour_from_line(p)
-		if "menu button hover" in p:
-			colours.status_text_over = get_colour_from_line(p)
-		if "queue panel" in p:
-			colours.queue_background = get_colour_from_line(p)
-		if "side panel" in p:
-			colours.side_panel_background = get_colour_from_line(p)
-			colours.playlist_box_background = colours.side_panel_background
-		if "gallery background" in p:
-			colours.gallery_background = get_colour_from_line(p)
-		if "playlist panel" in p:  # bad name
-			colours.playlist_panel_background = get_colour_from_line(p)
-		if "tracklist panel" in p:
-			colours.playlist_panel_background = get_colour_from_line(p)
-		if "track line" in p:
-			colours.title_text = get_colour_from_line(p)
-		if "track missing" in p:
-			colours.playlist_text_missing = get_colour_from_line(p)
-		if "playing highlight" in p:
-			colours.row_playing_highlight = get_colour_from_line(p)
-		if "track time" in p:
-			colours.bar_time = get_colour_from_line(p)
-		if "fav line" in p:
-			colours.star_line = get_colour_from_line(p)
-		if "folder title" in p:
-			colours.folder_title = get_colour_from_line(p)
-		if "folder line" in p:
-			colours.folder_line = get_colour_from_line(p)
-		if "buttons off" in p:
-			colours.media_buttons_off = get_colour_from_line(p)
-		if "buttons over" in p:
-			colours.media_buttons_over = get_colour_from_line(p)
-		if "buttons active" in p:
-			colours.media_buttons_active = get_colour_from_line(p)
-		if "playing time" in p:
-			colours.time_playing = get_colour_from_line(p)
-		if "track index" in p:
-			colours.index_text = get_colour_from_line(p)
-		if "track playing" in p:
-			colours.title_playing = get_colour_from_line(p)
-		if "select highlight" in p:
-			colours.row_select_highlight = get_colour_from_line(p)
-		if "track artist" in p:
-			colours.artist_text = get_colour_from_line(p)
-		if "tab active line" in p:  # bad name
-			colours.tab_text_active = get_colour_from_line(p)
-		if "tab line" in p:  # bad name
-			colours.tab_text = get_colour_from_line(p)
-		if "tab active text" in p:
-			colours.tab_text_active = get_colour_from_line(p)
-		if "tab text" in p:
-			colours.tab_text = get_colour_from_line(p)
-		if "tab background" in p:
-			colours.tab_background = get_colour_from_line(p)
-		if "tab over" in p:
-			colours.tab_highlight = get_colour_from_line(p)
-		if "tab active background" in p:
-			colours.tab_background_active = get_colour_from_line(p)
-		if "title info" in p:
-			colours.side_bar_line1 = get_colour_from_line(p)
-		if "extra info" in p:
-			colours.side_bar_line2 = get_colour_from_line(p)
-		if "bottom title" in p:
-			colours.bar_title_text = get_colour_from_line(p)
-		if "scroll bar" in p:
-			colours.scroll_colour = get_colour_from_line(p)
-		if "seek bar" in p:
-			colours.seek_bar_fill = get_colour_from_line(p)
-		if "seek bg" in p:
-			colours.seek_bar_background = get_colour_from_line(p)
-		if "volume bar" in p:
-			colours.volume_bar_fill = get_colour_from_line(p)
-		if "volume bg" in p:
-			colours.volume_bar_background = get_colour_from_line(p)
-		if "mode off" in p:
-			colours.mode_button_off = get_colour_from_line(p)
-		if "mode over" in p:
-			colours.mode_button_over = get_colour_from_line(p)
-		if "mode on" in p:
-			colours.mode_button_active = get_colour_from_line(p)
-		if "art border" in p:
-			colours.art_box = get_colour_from_line(p)
-		if "tb line" in p:
-			colours.tb_line = get_colour_from_line(p)
-		if "music vis" in p:
-			colours.vis_colour = get_colour_from_line(p)
-		if "menu background" in p:
-			colours.menu_background = get_colour_from_line(p)
-		if "menu text" in p:
-			colours.menu_text = get_colour_from_line(p)
-		if "menu disable" in p:
-			colours.menu_text_disabled = get_colour_from_line(p)
-		if "menu icons" in p:
-			colours.menu_icons = get_colour_from_line(p)
-		if "menu highlight" in p:
-			colours.menu_highlight_background = get_colour_from_line(p)
-		if "menu border" in p:
-			colours.menu_tab = get_colour_from_line(p)
-		if "lyrics showcase" in p:
-			colours.lyrics = get_colour_from_line(p)
-		if "bottom panel" in p:
-			colours.bottom_panel_colour = get_colour_from_line(p)
-			# colours.menu_background = colours.bottom_panel_colour
-		if "mini bg" in p:
-			colours.mini_mode_background = get_colour_from_line(p)
-		if "mini border" in p:
-			colours.mini_mode_border = get_colour_from_line(p)
-		if "mini text 1" in p:
-			colours.mini_mode_text_1 = get_colour_from_line(p)
-		if "mini text 2" in p:
-			colours.mini_mode_text_2 = get_colour_from_line(p)
-		if "column-" in p:
-			key = p[p.find("column-") + 7:].replace("-", " ").lower().title().rstrip()
-			value = get_colour_from_line(p)
-			colours.column_colours[key] = value
-		if "column+" in p:
-			key = p[p.find("column+") + 7:].replace("-", " ").lower().title().rstrip()
-			value = get_colour_from_line(p)
-			colours.column_colours_playing[key] = value
-		if "menu bg" in p:
-			colours.menu_background = get_colour_from_line(p)
-		if "playlist box bg" in p:  # bad name
-			colours.playlist_box_background = get_colour_from_line(p)
-		if "playlist background" in p:
-			colours.playlist_box_background = get_colour_from_line(p)
-
-		if "box background" in p:
-			colours.box_background = get_colour_from_line(p)
-		if "box border" in p:
-			colours.box_border = get_colour_from_line(p)
-		if "box text border" in p:
-			colours.box_text_border = get_colour_from_line(p)
-		if "box text label" in p:
-			colours.box_text_label = get_colour_from_line(p)
-
-		if "box title text" in p:
-			colours.box_title_text = get_colour_from_line(p)
-		if "box text normal" in p:
-			colours.box_text = get_colour_from_line(p)
-		if "box sub text" in p:
-			colours.box_sub_text = get_colour_from_line(p)
-		if "box input text" in p:
-			colours.box_input_text = get_colour_from_line(p)
-
-		if "box button text highlight" in p:
-			colours.box_button_text_highlight = get_colour_from_line(p)
-		if "box button text normal" in p:
-			colours.box_button_text = get_colour_from_line(p)
-		if "box button background normal" in p:
-			colours.box_button_background = get_colour_from_line(p)
-		if "box button background highlight" in p:
-			colours.box_button_background_highlight = get_colour_from_line(p)
-		if "box button border" in p:
-			colours.box_check_border = get_colour_from_line(p)
-
-		if "window buttons background" in p:
-			colours.window_buttons_bg = get_colour_from_line(p)
-		if "window buttons on" in p:
-			colours.window_buttons_bg_over = get_colour_from_line(p)
-		if "window buttons icon off" in p:
-			colours.window_button_icon_off = get_colour_from_line(p)
-			colours.window_button_x_off = colours.window_button_icon_off
-		if "window buttons icon over" in p:
-			colours.window_buttons_icon_over = get_colour_from_line(p)
-			colours.window_button_x_on = colours.window_buttons_icon_over
-		if "window button x on" in p:
-			colours.window_button_x_on = get_colour_from_line(p)
-		if "window button x off" in p:
-			colours.window_button_x_off = get_colour_from_line(p)
-		if "column bar background" in p:
-			colours.column_bar_background = get_colour_from_line(p)
-
-		if "artist bio background" in p:
-			colours.artist_bio_background = get_colour_from_line(p)
-		if "artist bio text" in p:
-			colours.artist_bio_text = get_colour_from_line(p)
-		# if "panel button off" in p:
-		#	 colours.corner_button = get_colour_from_line(p)
-		# if "panel button on" in p:
-		#	 colours.corner_button_active = get_colour_from_line(p)
-
-	colours.post_config()
-	if colours.lm:
-		colours.light_mode()
 
 
 class Drawable:

--- a/src/tauon/t_modules/t_webserve.py
+++ b/src/tauon/t_modules/t_webserve.py
@@ -267,7 +267,7 @@ def webserve2(pctl: PlayerCtl, prefs: Prefs, gui: GuiVar, album_art_gen: AlbumAr
 				else:
 					playlist = pctl.multi_playlist[playlist_index].playlist_ids
 				track_id = playlist[track_position]
-				track = pctl.g(track_id)
+				track = pctl.get_track(track_id)
 
 			data = {}
 			data["title"] = track.title
@@ -305,7 +305,7 @@ def webserve2(pctl: PlayerCtl, prefs: Prefs, gui: GuiVar, album_art_gen: AlbumAr
 			if path.startswith("/api1/pic/small/"):
 				value = path[16:]
 				if value.isalnum() and int(value) in pctl.master_library:
-					track = pctl.g(int(value))
+					track = pctl.get_track(int(value))
 					raw = album_art_gen.save_thumb(track, (75, 75), "")
 					if raw:
 						self.send_response(200)
@@ -326,7 +326,7 @@ def webserve2(pctl: PlayerCtl, prefs: Prefs, gui: GuiVar, album_art_gen: AlbumAr
 				value = path[17:]
 				logging.info(value)
 				if value.isalnum() and int(value) in pctl.master_library:
-					track = pctl.g(int(value))
+					track = pctl.get_track(int(value))
 					raw = album_art_gen.save_thumb(track, (1000, 1000), "")
 					if raw:
 						self.send_response(200)
@@ -346,7 +346,7 @@ def webserve2(pctl: PlayerCtl, prefs: Prefs, gui: GuiVar, album_art_gen: AlbumAr
 			if path.startswith("/api1/lyrics/"):
 				value = path[13:]
 				if value.isalnum() and int(value) in pctl.master_library:
-					track = pctl.g(int(value))
+					track = pctl.get_track(int(value))
 					data = {}
 					data["track_id"] = track.index
 					data["lyrics_text"] = track.lyrics
@@ -500,9 +500,9 @@ def webserve2(pctl: PlayerCtl, prefs: Prefs, gui: GuiVar, album_art_gen: AlbumAr
 						playlist = pctl.multi_playlist[pl].playlist_ids
 						p = int(levels[4])
 						if p < len(playlist):
-							track = pctl.g(playlist[p])
+							track = pctl.get_track(playlist[p])
 							while True:
-								if p < 0 or pctl.g(playlist[p]).parent_folder_path != track.parent_folder_path:
+								if p < 0 or pctl.get_track(playlist[p]).parent_folder_path != track.parent_folder_path:
 									p += 1
 									break
 								p -= 1
@@ -588,7 +588,7 @@ def webserve2(pctl: PlayerCtl, prefs: Prefs, gui: GuiVar, album_art_gen: AlbumAr
 						parent = ""
 						album_id = 0
 						for i, id in enumerate(playlist):
-							tr = pctl.g(id)
+							tr = pctl.get_track(id)
 							if i == 0:
 								parent = tr.parent_folder_path
 							elif parent != tr.parent_folder_path:
@@ -658,7 +658,7 @@ def webserve2(pctl: PlayerCtl, prefs: Prefs, gui: GuiVar, album_art_gen: AlbumAr
 
 				if p < len(playlist):
 					while True:
-						if p < 0 or pctl.g(playlist[p]).parent_folder_path != track.parent_folder_path:
+						if p < 0 or pctl.get_track(playlist[p]).parent_folder_path != track.parent_folder_path:
 							p += 1
 							break
 						p -= 1


### PR DESCRIPTION
Fixes up one issue out of two in #1291

Had to move the Menu class so the diff is a bit wonky when viewed together.

Fixes a bunch of missed g() renames.

Enables additional (??? docs make it look like they're default) warnings like:
```python
/home/user/Projects/Tauon/.venv/lib/python3.12/site-packages/tauon/t_modules/t_main.py:44663: 
  ResourceWarning: unclosed file 
    <_io.TextIOWrapper name='/home/user/Projects/Tauon/.venv/lib/python3.12/site-packages/tauon/theme/Turbo.ttheme' mode='r' encoding='utf-8'>
  load_theme(colours, theme_item[0])
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```

Fixed all revealed warnings by the above, this involves not closing file handles in various places, themes and DB accesses included.  
May fix memory leaks that some people complained about in #1128.

Add a way to run dirty venv to `run.sh` - this moves the current options up by one sans numero 1.