### PR TITLE
Use Listening activity type in Discord RPC

### DIFF
--- a/requirements_optional.txt
+++ b/requirements_optional.txt
@@ -6,7 +6,10 @@ opencc
 #picard - picard 2.12.3 requires charset-normalizer~=3.3.2, but you have charset-normalizer 3.4.0 which is incompatible.
 plexapi
 PyChromecast
-pypresence
+# the latest pypresence pypi release (4.3.0) doesn't support ActivityType yet,
+# but they already implemented it on commit f856ccaaeb2321f64f9692b75dc3ceda5c927f42.
+# TODO: move to a proper release when possible
+pypresence @ git+https://github.com/qwertyquerty/pypresence@f856ccaaeb2321f64f9692b75dc3ceda5c927f42
 setproctitle
 tekore
 tidalapi

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -375,7 +375,7 @@ else:
 #	logging.exception("Unable to import rpc, Discord Rich Presence will be disabled.")
 discord_allow = False
 try:
-	from pypresence import Presence
+	from pypresence import Presence, ActivityType
 except ModuleNotFoundError:
 	logging.warning("Unable to import pypresence, Discord Rich Presence will be disabled.")
 except Exception:
@@ -24235,6 +24235,7 @@ def discord_loop():
 					large_image = url
 					small_image = "tauon-standard"
 				RPC.update(
+					activity_type = ActivityType.LISTENING,
 					pid=pid,
 					state=album,
 					details=title,
@@ -24245,6 +24246,7 @@ def discord_loop():
 			else:
 				#logging.info("Discord RPC - Stop")
 				RPC.update(
+					activity_type = ActivityType.LISTENING,
 					pid=pid,
 					state="Idle",
 					large_image="tauon-standard")


### PR DESCRIPTION
Discord added support for different activity types some time ago, but Tauon still uses the "Playing" activity type:

![image](https://github.com/user-attachments/assets/1b999e3b-31e5-40ad-8126-ded8b0452623) ![image](https://github.com/user-attachments/assets/43c089fe-52c7-4cb8-b64f-617d42c66b34)

`pypresence` got [support for it](https://github.com/qwertyquerty/pypresence/commit/f856ccaaeb2321f64f9692b75dc3ceda5c927f42) on August 2024, but the latest pypi release (4.3.0, from 2023) is outdated.

This PR implements it, fetching `pypresence` via Git.

![image](https://github.com/user-attachments/assets/8630d795-5475-4e4f-8417-9a1efc87c97d) ![image](https://github.com/user-attachments/assets/0c020a29-806b-4a89-9077-43434c4c7cd2)
