### PR TITLE
Add Windows CI and fix up Linux and macOS

### DIFF
--- a/.github/workflows/build_Linux.yaml
+++ b/.github/workflows/build_Linux.yaml
@@ -38,6 +38,7 @@ jobs:
             libopenmpt-dev \
             libopusfile-dev \
             libsamplerate0-dev \
+            libsdl2-image-dev \
             libvorbis-dev \
             libwavpack-dev
           # JPEG-XL hack since 24.04 is too old

--- a/.github/workflows/build_Linux.yaml
+++ b/.github/workflows/build_Linux.yaml
@@ -25,6 +25,7 @@ jobs:
             gettext \
             gobject-introspection \
             gir1.2-rsvg-2.0 \
+            kde-config-gtk-style \
             libgirepository1.0-dev \
             python3-gi-cairo \
             libayatana-appindicator3-dev \

--- a/.github/workflows/build_Linux.yaml
+++ b/.github/workflows/build_Linux.yaml
@@ -24,6 +24,7 @@ jobs:
           sudo apt-get install -y \
             gettext \
             gobject-introspection \
+            gir1.2-rsvg-2.0 \
             libgirepository1.0-dev \
             python3-gi-cairo \
             libcairo2-dev \

--- a/.github/workflows/build_Linux.yaml
+++ b/.github/workflows/build_Linux.yaml
@@ -27,6 +27,7 @@ jobs:
             gir1.2-rsvg-2.0 \
             libgirepository1.0-dev \
             python3-gi-cairo \
+            libayatana-appindicator3-dev \
             libcairo2-dev \
             libpipewire-0.3-dev \
             libdbus-1-dev \

--- a/.github/workflows/build_Windows_MINGW64.yaml
+++ b/.github/workflows/build_Windows_MINGW64.yaml
@@ -100,5 +100,5 @@ jobs:
       - name: Upload ZIP artifact
         uses: actions/upload-artifact@v4
         with:
-          name: TauonMusicBox-linux
+          name: TauonMusicBox-windows
           path: dist/zip/TauonMusicBox.zip

--- a/.github/workflows/build_Windows_MINGW64.yaml
+++ b/.github/workflows/build_Windows_MINGW64.yaml
@@ -23,6 +23,7 @@ jobs:
             ca-certificates
             cmake
             ninja
+            zip
             mingw-w64-x86_64-flac
             mingw-w64-x86_64-gcc
             mingw-w64-x86_64-gobject-introspection

--- a/.github/workflows/build_Windows_MINGW64.yaml
+++ b/.github/workflows/build_Windows_MINGW64.yaml
@@ -1,0 +1,103 @@
+name: Build Windows (MINGW64) app
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      # TODO(Martin): This is duped from the file in extra, install from said file somehow instead
+      - name: Set up MSYS2 MinGW-W64
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: mingw64
+          update: true
+          install: >-
+            base-devel
+            ca-certificates
+            cmake
+            ninja
+            mingw-w64-x86_64-flac
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-gobject-introspection
+            mingw-w64-x86_64-gtk3
+            mingw-w64-x86_64-libgme
+            mingw-w64-x86_64-libopenmpt
+            mingw-w64-x86_64-libsamplerate
+            mingw-w64-x86_64-opusfile
+            mingw-w64-x86_64-pkgconf
+            mingw-w64-x86_64-python3
+            mingw-w64-x86_64-python3-gobject
+            mingw-w64-x86_64-python3-pillow
+            mingw-w64-x86_64-python3-pip
+            mingw-w64-x86_64-python-websocket-client
+            mingw-w64-x86_64-python-zeroconf
+            mingw-w64-x86_64-rust
+            mingw-w64-x86_64-SDL2
+            mingw-w64-x86_64-SDL2_image
+            mingw-w64-x86_64-wavpack
+            mingw-w64-x86_64-zlib
+
+      - name: Update CA trust and hack opusfile
+        shell: msys2 {0}
+        run: |
+          update-ca-trust
+          # https://github.com/xiph/opusfile/pull/47
+          sed -i 's,<opus_multistream.h>,<opus/opus_multistream.h>,' /mingw64/include/opus/opusfile.h
+
+      - name: Install Python dependencies and setup venv
+        shell: msys2 {0}
+        run: |
+          python -m pip install --upgrade pip
+          python -m venv .venv
+          source .venv/bin/activate
+          export CFLAGS="-I/mingw64/include"
+          pip install \
+            -r requirements.txt \
+            build \
+            pyinstaller
+
+      - name: Build the project using python-build
+        shell: msys2 {0}
+        run: |
+          source .venv/bin/activate
+          python -m compile_translations
+          python -m build --wheel
+
+      - name: Install the project into a venv
+        shell: msys2 {0}
+        run: |
+          source .venv/bin/activate
+          pip install --prefix ".venv" dist/*.whl
+
+      - name: "[DEBUG] List all files"
+        shell: msys2 {0}
+        run: find .
+
+      - name: Build Windows App with PyInstaller
+        shell: msys2 {0}
+        run: |
+          source .venv/bin/activate
+          pyinstaller --log-level=DEBUG windows.spec
+
+      - name: Create ZIP
+        shell: msys2 {0}
+        run: |
+          mkdir -p dist/zip
+          APP_NAME="TauonMusicBox"
+          APP_PATH="dist/${APP_NAME}"
+          ZIP_PATH="dist/zip/${APP_NAME}.zip"
+
+          zip -r "${ZIP_PATH}" "${APP_PATH}"
+
+      - name: Upload ZIP artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: TauonMusicBox-linux
+          path: dist/zip/TauonMusicBox.zip

--- a/.github/workflows/build_macOS.yaml
+++ b/.github/workflows/build_macOS.yaml
@@ -44,6 +44,7 @@ jobs:
           python -m venv .venv
           source .venv/bin/activate
           export CXXFLAGS="-I/opt/homebrew/include"
+          export LDFLAGS="-L/opt/homebrew/lib"
           pip install \
             -r requirements.txt \
             build
@@ -51,7 +52,6 @@ jobs:
           pip install https://github.com/pyinstaller/pyinstaller/archive/develop.zip
 #            pyinstaller
 #          CFLAGS: "-I/opt/homebrew/include"
-#          LDFLAGS: "-L/opt/homebrew/lib"
 
       - name: Build the project using python-build
         run: |

--- a/.github/workflows/build_macOS.yaml
+++ b/.github/workflows/build_macOS.yaml
@@ -43,14 +43,13 @@ jobs:
           python -m pip install --upgrade pip
           python -m venv .venv
           source .venv/bin/activate
+          export CXXFLAGS="-I/opt/homebrew/include"
           pip install \
             -r requirements.txt \
             build
           # Hack until pyinstaller has a release newer than 6.11.1 - https://github.com/pyinstaller/pyinstaller/releases
           pip install https://github.com/pyinstaller/pyinstaller/archive/develop.zip
-#            \
 #            pyinstaller
-#          pip uninstall pyinstaller
 #          CFLAGS: "-I/opt/homebrew/include"
 #          LDFLAGS: "-L/opt/homebrew/lib"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Changelog
 ### v7.9.0
 
 - **Added** TIDAL support
-- **Added** macOS (experimental) and Linux automated CI builds
+- **Added** Linux/macOS/Windows CI builds, restoring Windows and macOS build support
 - **Changed** portable installations now save `cache` and `user-data` directiories in `src/tauon/`, move existing directories there if necessary
 - **Fixed** Windows support
 - **Fixed** crashes related to PipeWire [#1250](https://github.com/Taiko2k/Tauon/issues/1250)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ Changelog
 - **Added** TIDAL support
 - **Added** Linux/macOS/Windows CI builds, restoring Windows and macOS build support
 - **Changed** portable installations now save `cache` and `user-data` directiories in `src/tauon/`, move existing directories there if necessary
-- **Fixed** Windows support
 - **Fixed** crashes related to PipeWire [#1250](https://github.com/Taiko2k/Tauon/issues/1250)
 - **Fixed** audio cutting out on the PipeWire backend with specific custom quantum settings [#1245](https://github.com/Taiko2k/Tauon/issues/1245)
 - **Fixed** wrong encoding used for some tags in XSPF exports [#1331](https://github.com/Taiko2k/Tauon/issues/1331)

--- a/extra/requirements_linux.txt
+++ b/extra/requirements_linux.txt
@@ -7,6 +7,7 @@ PlexAPI
 PyGObject
 pylast>=3.1.0
 PySDL2
+pysdl2-dll
 requests
 Send2Trash
 unidecode

--- a/extra/requirements_macos.txt
+++ b/extra/requirements_macos.txt
@@ -5,8 +5,8 @@ Pillow
 PlexAPI
 PyGObject
 pylast>=3.1.0
-pysdl2-dll
 PySDL2
+pysdl2-dll
 requests
 Send2Trash
 unidecode

--- a/extra/requirements_optional.txt
+++ b/extra/requirements_optional.txt
@@ -1,5 +1,5 @@
 colored_traceback
-jxlpy;                       sys_platform != 'darwin' # macOS hates it - fails to find jxl/types.h - https://github.com/olokelo/jxlpy/issues/25#issuecomment-2547928563
+jxlpy
 #librespot - https://github.com/kokarare1212/librespot-python/pull/286
 natsort
 opencc;                      sys_platform != 'win32'

--- a/extra/requirements_windows.txt
+++ b/extra/requirements_windows.txt
@@ -1,19 +1,16 @@
 beautifulsoup4
-comtypes # Windows dep
-infi.systray
-keyboard # Windows dep
+comtypes
+lynxtray
+keyboard
 musicbrainzngs
 mutagen
-natsort # optdep
-opencc-python-reimplemented # Windows version of openCC optdep
 Pillow
 PlexAPI
 PyGObject
 pyinstaller
 pylast>=3.1.0
-pypresence # optdep
 PySDL2
+pysdl2-dll
 requests
 Send2Trash
-tekore # optdep
 unidecode

--- a/linux.spec
+++ b/linux.spec
@@ -5,6 +5,8 @@ a = Analysis(
 	pathex=[],
 	binaries=[],
 	datas=[
+		("/usr/lib/x86_64-linux-gnu/gtk-3.0/modules/libcolorreload-gtk-module.so", ".")
+		("/usr/lib/x86_64-linux-gnu/gtk-3.0/modules/libwindow-decorations-gtk-module.so", ".")
 		("src/tauon/assets", "assets"),
 		("src/tauon/locale", "locale"),
 		("src/tauon/theme", "theme"),

--- a/linux.spec
+++ b/linux.spec
@@ -5,8 +5,8 @@ a = Analysis(
 	pathex=[],
 	binaries=[],
 	datas=[
-		("/usr/lib/x86_64-linux-gnu/gtk-3.0/modules/libcolorreload-gtk-module.so", "lib/gtk-3.0/modules/libcolorreload-gtk-module.so"),
-		("/usr/lib/x86_64-linux-gnu/gtk-3.0/modules/libwindow-decorations-gtk-module.so", "lib/gtk-3.0/modules/libwindow-decorations-gtk-module.so"),
+		("/usr/lib/x86_64-linux-gnu/gtk-3.0/modules/libcolorreload-gtk-module.so", "lib/gtk-3.0/modules"),
+		("/usr/lib/x86_64-linux-gnu/gtk-3.0/modules/libwindow-decorations-gtk-module.so", "lib/gtk-3.0/modules"),
 		("src/tauon/assets", "assets"),
 		("src/tauon/locale", "locale"),
 		("src/tauon/theme", "theme"),

--- a/linux.spec
+++ b/linux.spec
@@ -5,8 +5,8 @@ a = Analysis(
 	pathex=[],
 	binaries=[],
 	datas=[
-#		("/usr/lib/x86_64-linux-gnu/gtk-3.0/modules/libcolorreload-gtk-module.so", "."),
-#		("/usr/lib/x86_64-linux-gnu/gtk-3.0/modules/libwindow-decorations-gtk-module.so", "."),
+		("/usr/lib/x86_64-linux-gnu/gtk-3.0/modules/libcolorreload-gtk-module.so", "lib/gtk-3.0/modules/libcolorreload-gtk-module.so"),
+		("/usr/lib/x86_64-linux-gnu/gtk-3.0/modules/libwindow-decorations-gtk-module.so", "lib/gtk-3.0/modules/libwindow-decorations-gtk-module.so"),
 		("src/tauon/assets", "assets"),
 		("src/tauon/locale", "locale"),
 		("src/tauon/theme", "theme"),

--- a/linux.spec
+++ b/linux.spec
@@ -5,8 +5,8 @@ a = Analysis(
 	pathex=[],
 	binaries=[],
 	datas=[
-		("/usr/lib/x86_64-linux-gnu/gtk-3.0/modules/libcolorreload-gtk-module.so", ".")
-		("/usr/lib/x86_64-linux-gnu/gtk-3.0/modules/libwindow-decorations-gtk-module.so", ".")
+		("/usr/lib/x86_64-linux-gnu/gtk-3.0/modules/libcolorreload-gtk-module.so", "."),
+		("/usr/lib/x86_64-linux-gnu/gtk-3.0/modules/libwindow-decorations-gtk-module.so", "."),
 		("src/tauon/assets", "assets"),
 		("src/tauon/locale", "locale"),
 		("src/tauon/theme", "theme"),

--- a/linux.spec
+++ b/linux.spec
@@ -5,8 +5,8 @@ a = Analysis(
 	pathex=[],
 	binaries=[],
 	datas=[
-		("/usr/lib/x86_64-linux-gnu/gtk-3.0/modules/libcolorreload-gtk-module.so", "."),
-		("/usr/lib/x86_64-linux-gnu/gtk-3.0/modules/libwindow-decorations-gtk-module.so", "."),
+#		("/usr/lib/x86_64-linux-gnu/gtk-3.0/modules/libcolorreload-gtk-module.so", "."),
+#		("/usr/lib/x86_64-linux-gnu/gtk-3.0/modules/libwindow-decorations-gtk-module.so", "."),
 		("src/tauon/assets", "assets"),
 		("src/tauon/locale", "locale"),
 		("src/tauon/theme", "theme"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@
 #		"dbus-python;                 sys_platform == 'linux'",
 #		"pysdl2-dll;                  sys_platform == 'darwin'", # Don't rely on system https://github.com/py-sdl/py-sdl2#requirements
 #		"comtypes;                    sys_platform == 'win32'",
-#		"infi.systray;                sys_platform == 'win32'",
+#		"lynxtray;                    sys_platform == 'win32'",
 #		"keyboard;                    sys_platform == 'win32'",
 #		"Pillow;                      sys_platform != 'win32'",
 #		"opencc;                      sys_platform != 'win32'", # OPTDEP

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ Send2Trash
 unidecode
 comtypes;                    sys_platform == 'win32'
 dbus-python;                 sys_platform == 'linux'
-jxlpy;                       sys_platform != 'darwin' # macOS hates it - fails to find jxl/types.h - https://github.com/olokelo/jxlpy/issues/25#issuecomment-2547928563
+jxlpy
 keyboard;                    sys_platform == 'win32'
 lynxtray;                    sys_platform == 'win32'
 opencc;                      sys_platform != 'win32' # optional

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ unidecode
 dbus-python;                 sys_platform == 'linux'
 pysdl2-dll # Don't rely on system SDL2 https://github.com/py-sdl/py-sdl2#requirements
 comtypes;                    sys_platform == 'win32'
-infi.systray;                sys_platform == 'win32'
+lynxtray;                    sys_platform == 'win32'
 keyboard;                    sys_platform == 'win32'
 Pillow
 opencc;                      sys_platform != 'win32' # OPTDEP

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,4 +26,6 @@ tidalapi # optional
 colored_traceback # very optional
 #pyinstaller
 #librespot - https://github.com/kokarare1212/librespot-python/pull/286
-#picard - picard 2.12.3 requires charset-normalizer~=3.3.2, but you have charset-normalizer 3.4.0 which is incompatible.
+#picard - Waiting for release newer than 2.12.3 which has a fix for this: picard
+#  2.12.3 requires charset-normalizer~=3.3.2, but you have charset-normalizer 3.4.0 which is incompatible.
+#  https://github.com/metabrainz/picard/releases

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,30 +1,29 @@
 beautifulsoup4
 musicbrainzngs
 mutagen
+Pillow
 PlexAPI
 PyGObject
 pylast>=3.1.0
 PySDL2
+pysdl2-dll # Don't rely on system SDL2 https://github.com/py-sdl/py-sdl2#requirements
 requests
 Send2Trash
 unidecode
-dbus-python;                 sys_platform == 'linux'
-pysdl2-dll # Don't rely on system SDL2 https://github.com/py-sdl/py-sdl2#requirements
 comtypes;                    sys_platform == 'win32'
-lynxtray;                    sys_platform == 'win32'
-keyboard;                    sys_platform == 'win32'
-Pillow
-opencc;                      sys_platform != 'win32' # OPTDEP
-opencc-python-reimplemented; sys_platform == 'win32' # OPTDEP
-#pyinstaller # ;                 sys_platform != 'linux' # for macOS at least
-pypresence # optdep
-tekore # optdep,
-natsort # optdep
+dbus-python;                 sys_platform == 'linux'
 jxlpy;                       sys_platform != 'darwin' # macOS hates it - fails to find jxl/types.h - https://github.com/olokelo/jxlpy/issues/25#issuecomment-2547928563
+keyboard;                    sys_platform == 'win32'
+lynxtray;                    sys_platform == 'win32'
+opencc;                      sys_platform != 'win32' # optional
+opencc-python-reimplemented; sys_platform == 'win32' # optional
+pypresence # optional
+tekore # optional
+natsort # optional
+PyChromecast # optional
+setproctitle # optional
+tidalapi # optional
+colored_traceback # very optional
+#pyinstaller
 #librespot - https://github.com/kokarare1212/librespot-python/pull/286
 #picard - picard 2.12.3 requires charset-normalizer~=3.3.2, but you have charset-normalizer 3.4.0 which is incompatible.
-PyChromecast # OPTDEP
-setproctitle # OPTDEP
-tidalapi # OPTDEP
-colored_traceback # very opt
-zeroconf # pychromecast dependency, TODO(Martin): This is a test, remove me

--- a/run.sh
+++ b/run.sh
@@ -87,6 +87,7 @@ compile_phazor() {
 }
 
 compile_phazor_pipewire() {
+	compile_phazor
 	outFile="build/libphazor-pw.so"
 	mkdir -p build
 	gcc \

--- a/run.sh
+++ b/run.sh
@@ -6,42 +6,13 @@ win_build() {
 	rm -rf dist/tauon
 	# Had to do Windows Security -> Virus & thread protection*2 -> Manage settings -> Windows Real-time protection: off
 
-	# TODO(Martin): pkg_resources is deprecated, does it still need to be there?
-	# https://setuptools.pypa.io/en/latest/pkg_resources.html
-	pyinstaller \
-		--name TauonMusicBox \
-		--noconfirm \
-		--additional-hooks-dir='extra\pyinstaller-hooks' \
-		--hidden-import 'infi.systray' \
-		--hidden-import 'pylast' \
-		--hidden-import 'tekore' \
-		--hidden-import 'phazor' \
-		--add-binary 'C:\msys64\mingw64\bin\libFLAC.dll;.' \
-		--add-binary 'C:\msys64\mingw64\bin\libmpg123-0.dll;.' \
-		--add-binary 'C:\msys64\mingw64\bin\libogg-0.dll;.' \
-		--add-binary 'C:\msys64\mingw64\bin\libopenmpt-0.dll;.' \
-		--add-binary 'C:\msys64\mingw64\bin\libopus-0.dll;.' \
-		--add-binary 'C:\msys64\mingw64\bin\libopusfile-0.dll;.' \
-		--add-binary 'C:\msys64\mingw64\bin\libsamplerate-0.dll;.' \
-		--add-binary 'C:\msys64\mingw64\bin\libvorbis-0.dll;.' \
-		--add-binary 'C:\msys64\mingw64\bin\libvorbisfile-3.dll;.' \
-		--add-binary 'C:\msys64\mingw64\bin\libwavpack-1.dll;.' \
-		--add-binary 'C:\msys64\mingw64\bin\SDL2.dll;.' \
-		--add-binary 'C:\msys64\mingw64\bin\SDL2_image.dll;.' \
-		--add-binary 'C:\msys64\mingw64\bin\libgme.dll;.' \
-		--hidden-import 'pip' \
-		--hidden-import 'packaging.requirements' \
-		--hidden-import 'pkg_resources.py2_warn' \
-		--hidden-import 'requests' \
-		src/tauon/__main__.py \
-		-w -i src/tauon/assets/icon.ico
+	pyinstaller --log-level=DEBUG windows.spec
 
 	mkdir -p dist/TauonMusicBox/tekore
 	mkdir -p dist/TauonMusicBox/etc
 
 	#cp C:/msys64/mingw64/lib/python3.13/site-packages/tekore/VERSION dist/tauon/tekore/VERSION
 
-	cp -r src/tauon/{theme,assets,locale,templates} dist/TauonMusicBox/
 	rm -rf dist/tauon/share/{icons,locale,tcl/tzdata} dist/TauonMusicBox/tcl/tzdata
 	cp -r fonts dist/tauon/ || echo 'fonts directory is not present!'
 	cp -r /mingw64/etc/fonts dist/TauonMusicBox/etc

--- a/src/tauon/__main__.py
+++ b/src/tauon/__main__.py
@@ -156,9 +156,9 @@ if "--no-start" in sys.argv:
 pyinstaller_mode = False
 if hasattr(sys, "_MEIPASS"):
 	pyinstaller_mode = True
-if str(install_directory).endswith("\\_internal"):
+if install_directory.name.endswith("_internal"):
 	pyinstaller_mode = True
-	install_directory = install_directory.parent
+#	install_directory = install_directory.parent
 
 if pyinstaller_mode:
 	os.environ["PATH"] += ":" + sys._MEIPASS

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -3138,7 +3138,7 @@ for t in range(2):
 		db_version = save[17]
 		if db_version != latest_db_version:
 			if db_version > latest_db_version:
-				logging.critical(f"Loaded DB version: '{db_version}' is newer than latest known DB version '{latest_db_version}', refusing to load!")
+				logging.critical(f"Loaded DB version: '{db_version}' is newer than latest known DB version '{latest_db_version}', refusing to load!\nAre you running an out of date Tauon version using Configuration directory from a newer one?")
 				sys.exit(42)
 			logging.warning(f"Loaded older DB version: {db_version}")
 		if save[63] is not None:

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -480,7 +480,7 @@ try:
 	import pylast
 	last_fm_enable = True
 	if pyinstaller_mode:
-		pylast.SSL_CONTEXT.load_verify_locations(os.path.join(install_directory, "certifi", "cacert.pem"))
+		pylast.SSL_CONTEXT.load_verify_locations(str(Path(install_directory) / "certifi" / "cacert.pem"))
 except Exception:
 	logging.exception("PyLast module not found, last fm will be disabled.")
 	last_fm_enable = False

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -3137,6 +3137,9 @@ for t in range(2):
 
 		db_version = save[17]
 		if db_version != latest_db_version:
+			if db_version > latest_db_version:
+				logging.critical(f"Loaded DB version: '{db_version}' is newer than latest known DB version '{latest_db_version}', refusing to load!")
+				sys.exit(42)
 			logging.warning(f"Loaded older DB version: {db_version}")
 		if save[63] is not None:
 			prefs.ui_scale = save[63]

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -5359,7 +5359,7 @@ class PlayerCtl:
 				if str(e) == "release unlocked lock":
 					logging.error("RuntimeError: Attempted to release already unlocked tray_lock")
 				else:
-					logging.exception("Unknown RuntimeError trying to release tray_lock: {e}")
+					logging.exception("Unknown RuntimeError trying to release tray_lock")
 			except Exception:
 				logging.exception("Failed to release tray_lock")
 
@@ -5960,7 +5960,7 @@ class PlayerCtl:
 				if str(e) == "release unlocked lock":
 					logging.error("RuntimeError: Attempted to release already unlocked player_lock")
 				else:
-					logging.exception("Unknown RuntimeError trying to release player_lock: {e}")
+					logging.exception("Unknown RuntimeError trying to release player_lock")
 			except Exception:
 				logging.exception("Unknown exception trying to release player_lock")
 
@@ -9010,7 +9010,7 @@ try:
 	from tauon.t_modules.t_chrome import Chrome
 	chrome = Chrome(tauon)
 except ModuleNotFoundError as e:
-	logging.debug("pychromecast import error: {e}")
+	logging.debug(f"pychromecast import error: {e}")
 	logging.warning("Unable to import Chrome(pychromecast), chromecast support will be disabled.")
 except Exception:
 	logging.exception("Unknown error trying to import Chrome(pychromecast), chromecast support will be disabled.")
@@ -27925,7 +27925,7 @@ def reload_backend() -> None:
 			if str(e) == "release unlocked lock":
 				logging.error("RuntimeError: Attempted to release already unlocked player_lock")
 			else:
-				logging.exception("Unknown RuntimeError trying to release player_lock: {e}")
+				logging.exception("Unknown RuntimeError trying to release player_lock")
 		except Exception:
 			logging.exception("Unknown error trying to release player_lock")
 
@@ -43784,7 +43784,7 @@ while pctl.running:
 				if str(e) == "release unlocked lock":
 					logging.error("RuntimeError: Attempted to release already unlocked player_lock")
 				else:
-					logging.exception("Unknown RuntimeError trying to release player_lock: {e}")
+					logging.exception("Unknown RuntimeError trying to release player_lock")
 			except Exception:
 				logging.exception("Unknown exception trying to release player_lock")
 
@@ -48254,7 +48254,7 @@ except RuntimeError as e:
 	if str(e) == "release unlocked lock":
 		logging.error("RuntimeError: Attempted to release already unlocked player_lock")
 	else:
-		logging.exception("Unknown RuntimeError trying to release player_lock: {e}")
+		logging.exception("Unknown RuntimeError trying to release player_lock")
 except Exception:
 	logging.exception("Unknown error trying to release player_lock")
 

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -9958,40 +9958,40 @@ def koel_get_album_thread() -> None:
 
 
 if system == "Windows" or msys:
-	from infi.systray import SysTrayIcon
+	from lynxtray import SysTrayIcon
 
 
 class STray:
 
-	def __init__(self):
+	def __init__(self) -> None:
 		self.active = False
 
-	def up(self, systray):
+	def up(self, systray: SysTrayIcon):
 		SDL_ShowWindow(t_window)
 		SDL_RaiseWindow(t_window)
 		SDL_RestoreWindow(t_window)
 		gui.lowered = False
 
-	def down(self):
+	def down(self) -> None:
 		if self.active:
 			SDL_HideWindow(t_window)
 
-	def advance(self, systray):
+	def advance(self, systray: SysTrayIcon) -> None:
 		pctl.advance()
 
-	def back(self, systray):
+	def back(self, systray: SysTrayIcon) -> None:
 		pctl.back()
 
-	def pause(self, systray):
+	def pause(self, systray: SysTrayIcon) -> None:
 		pctl.play_pause()
 
-	def track_stop(self, systray):
+	def track_stop(self, systray: SysTrayIcon) -> None:
 		pctl.stop()
 
-	def on_quit_callback(self, systray):
+	def on_quit_callback(self, systray: SysTrayIcon) -> None:
 		tauon.exit("Exit called from tray.")
 
-	def start(self):
+	def start(self) -> None:
 		menu_options = (("Show", None, self.up),
 						("Play/Pause", None, self.pause),
 						("Stop", None, self.track_stop),
@@ -10004,7 +10004,7 @@ class STray:
 		self.active = True
 		gui.tray_active = True
 
-	def stop(self):
+	def stop(self) -> None:
 		self.systray.shutdown()
 		self.active = False
 

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -12771,9 +12771,8 @@ class AlbumArt:
 		im.thumbnail((size, size), Image.Resampling.LANCZOS)
 		return im
 
-	def fast_display(self, index, location, box, source: list[tuple[int, str]], offset):
-
-		# Renders cached image only by given size for faster performance
+	def fast_display(self, index, location, box, source: list[tuple[int, str]], offset) -> int:
+		"""Renders cached image only by given size for faster performance"""
 
 		found_unit = None
 		max_h = 0
@@ -12828,7 +12827,7 @@ class AlbumArt:
 
 		return 0
 
-	def open_external(self, track_object: TrackClass):
+	def open_external(self, track_object: TrackClass) -> int:
 
 		index = track_object.index
 

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -590,7 +590,6 @@ if install_directory.startswith(("/opt/", "/usr/", "/app/", "/snap/")):
 
 # If we're installed, use home data locations
 if (install_mode and system == "Linux") or macos or msys:
-
 	cache_directory  = Path(GLib.get_user_cache_dir()) / "TauonMusicBox"
 	user_directory   = str(Path(GLib.get_user_data_dir()) / "TauonMusicBox")
 	config_directory = Path(GLib.get_user_data_dir()) / "TauonMusicBox"
@@ -625,7 +624,6 @@ if (install_mode and system == "Linux") or macos or msys:
 #	 install_mode = True
 #	 if not os.path.isdir(user_directory):
 #		 os.makedirs(user_directory)
-
 
 else:
 	logging.info("Running in portable mode")
@@ -9015,7 +9013,7 @@ except ModuleNotFoundError as e:
 except Exception:
 	logging.exception("Unknown error trying to import Chrome(pychromecast), chromecast support will be disabled.")
 finally:
-	logging.debug("Found import Chrome(pychromecast) for chromecast support")
+	logging.debug("Found Chrome(pychromecast) for chromecast support")
 
 tauon.chrome = chrome
 

--- a/src/tauon/t_modules/t_phazor.py
+++ b/src/tauon/t_modules/t_phazor.py
@@ -269,6 +269,16 @@ def player4(tauon: Tauon) -> None:
 		def close(self) -> None:
 			if self.decoder:
 				self.decoder.terminate()
+				if self.decoder.stdin:
+					logging.debug("Closing STDIN in FFrun")
+					self.decoder.stdin.close()
+				if self.decoder.stdout:
+					logging.debug("Closing STDOUT in FFrun")
+					self.decoder.stdout.close()
+				if self.decoder.stderr:
+					logging.debug("Closing STDERR in FFrun")
+					self.decoder.stderr.close()
+				self.decoder.wait()  # Ensure the process fully terminates
 			self.decoder = None
 
 		def start(self, uri: bytes, start_ms: int, samplerate: int) -> int:

--- a/windows.spec
+++ b/windows.spec
@@ -4,7 +4,9 @@ from pathlib import Path
 def find_msys64_path() -> Path:
 	"""Check common paths for MSYS2 installations"""
 	potential_paths = [
+		# This is the path the GitHub CI msys action uses
 		Path("D:\\a\\_temp\\msys64"),
+		# This is default Windows path
 		Path("C:\\msys64"),
 	]
 	for path in potential_paths:

--- a/windows.spec
+++ b/windows.spec
@@ -44,14 +44,10 @@ a = Analysis(
 		(".venv/lib/python3.12/site-packages/sdl2dll/dll", "sdl2dll/dll"),
 	],
 	hiddenimports=[
-		"infi.systray",
+		"lynxtray",
 		"pylast",
 		"tekore",
 		"phazor",
-		"pip",
-		"packaging.requirements",
-		"pkg_resources.py2_warn",
-		"requests",
 		# Zeroconf is hacked until this issue is resolved: https://github.com/pyinstaller/pyinstaller-hooks-contrib/issues/840
 		"zeroconf._utils.ipaddress",
 		"zeroconf._handlers.answers",

--- a/windows.spec
+++ b/windows.spec
@@ -52,6 +52,9 @@ a = Analysis(
 		"packaging.requirements",
 		"pkg_resources.py2_warn",
 		"requests",
+		# Zeroconf is hacked until this issue is resolved: https://github.com/pyinstaller/pyinstaller-hooks-contrib/issues/840
+		"zeroconf._utils.ipaddress",
+		"zeroconf._handlers.answers",
 	],
 	hookspath=["extra\\pyinstaller-hooks"],
 	hooksconfig={},

--- a/windows.spec
+++ b/windows.spec
@@ -1,8 +1,8 @@
 def find_msys64_path():
 	"""Check common paths for MSYS2 installations"""
 	potential_paths = [
-		"C:\\msys64",
 		"D:\\a\\_temp\\msys64",
+		"C:\\msys64",
 	]
 	for path in potential_paths:
 		if os.path.exists(path):

--- a/windows.spec
+++ b/windows.spec
@@ -22,6 +22,7 @@ a = Analysis(
 	pathex=[],
 	binaries=[
 		(str(Path(msys64_path) / "mingw64" / "bin" / "libFLAC.dll"),         "."),
+		(str(Path(msys64_path) / "mingw64" / "bin" / "libgme.dll"),          "."),
 		(str(Path(msys64_path) / "mingw64" / "bin" / "libmpg123-0.dll"),     "."),
 		(str(Path(msys64_path) / "mingw64" / "bin" / "libogg-0.dll"),        "."),
 		(str(Path(msys64_path) / "mingw64" / "bin" / "libopenmpt-0.dll"),    "."),
@@ -33,7 +34,6 @@ a = Analysis(
 		(str(Path(msys64_path) / "mingw64" / "bin" / "libwavpack-1.dll"),    "."),
 		(str(Path(msys64_path) / "mingw64" / "bin" / "SDL2.dll"),            "."),
 		(str(Path(msys64_path) / "mingw64" / "bin" / "SDL2_image.dll"),      "."),
-		(str(Path(msys64_path) / "mingw64" / "bin" / "libgme.dll"),          "."),
 	],
 	datas=[
 		("src/tauon/assets", "assets"),

--- a/windows.spec
+++ b/windows.spec
@@ -1,20 +1,33 @@
+def find_msys64_path():
+	"""Check common paths for MSYS2 installations"""
+	potential_paths = [
+		"C:\\msys64",
+		"D:\\a\\_temp\\msys64",
+	]
+	for path in potential_paths:
+		if os.path.exists(path):
+			return path
+	raise FileNotFoundError("MSYS2 base path not found in common locations")
+
+msys64_path = find_msys64_path()
+
 a = Analysis(
 	["src/tauon/__main__.py"],
 	pathex=[],
 	binaries=[
-		("C:\\msys64\\mingw64\\bin\\libFLAC.dll", "."),
-		("C:\\msys64\\mingw64\\bin\\libmpg123-0.dll", "."),
-		("C:\\msys64\\mingw64\\bin\\libogg-0.dll", "."),
-		("C:\\msys64\\mingw64\\bin\\libopenmpt-0.dll", "."),
-		("C:\\msys64\\mingw64\\bin\\libopus-0.dll", "."),
-		("C:\\msys64\\mingw64\\bin\\libopusfile-0.dll", "."),
-		("C:\\msys64\\mingw64\\bin\\libsamplerate-0.dll", "."),
-		("C:\\msys64\\mingw64\\bin\\libvorbis-0.dll", "."),
-		("C:\\msys64\\mingw64\\bin\\libvorbisfile-3.dll", "."),
-		("C:\\msys64\\mingw64\\bin\\libwavpack-1.dll", "."),
-		("C:\\msys64\\mingw64\\bin\\SDL2.dll", "."),
-		("C:\\msys64\\mingw64\\bin\\SDL2_image.dll", "."),
-		("C:\\msys64\\mingw64\\bin\\libgme.dll", "."),
+		(os.path.join(msys64_path, "\\mingw64\\bin\\libFLAC.dll"), "."),
+		(os.path.join(msys64_path, "\\mingw64\\bin\\libmpg123-0.dll"), "."),
+		(os.path.join(msys64_path, "\\mingw64\\bin\\libogg-0.dll"), "."),
+		(os.path.join(msys64_path, "\\mingw64\\bin\\libopenmpt-0.dll"), "."),
+		(os.path.join(msys64_path, "\\mingw64\\bin\\libopus-0.dll"), "."),
+		(os.path.join(msys64_path, "\\mingw64\\bin\\libopusfile-0.dll"), "."),
+		(os.path.join(msys64_path, "\\mingw64\\bin\\libsamplerate-0.dll"), "."),
+		(os.path.join(msys64_path, "\\mingw64\\bin\\libvorbis-0.dll"), "."),
+		(os.path.join(msys64_path, "\\mingw64\\bin\\libvorbisfile-3.dll"), "."),
+		(os.path.join(msys64_path, "\\mingw64\\bin\\libwavpack-1.dll"), "."),
+		(os.path.join(msys64_path, "\\mingw64\\bin\\SDL2.dll"), "."),
+		(os.path.join(msys64_path, "\\mingw64\\bin\\SDL2_image.dll"), "."),
+		(os.path.join(msys64_path, "\\mingw64\\bin\\libgme.dll"), "."),
 	],
 	datas=[],
 	hiddenimports=[

--- a/windows.spec
+++ b/windows.spec
@@ -1,33 +1,37 @@
-def find_msys64_path():
+from pathlib import Path
+
+
+def find_msys64_path() -> Path:
 	"""Check common paths for MSYS2 installations"""
 	potential_paths = [
-		"D:\\a\\_temp\\msys64",
-		"C:\\msys64",
+		Path("D:\\a\\_temp\\msys64"),
+		Path("C:\\msys64"),
 	]
 	for path in potential_paths:
-		if os.path.exists(path):
+		if path.exists():
 			return path
 	raise FileNotFoundError("MSYS2 base path not found in common locations")
 
 msys64_path = find_msys64_path()
+print(f"Found msys64 path: {msys64_path}")
 
 a = Analysis(
 	["src/tauon/__main__.py"],
 	pathex=[],
 	binaries=[
-		(os.path.join(msys64_path, "\\mingw64\\bin\\libFLAC.dll"), "."),
-		(os.path.join(msys64_path, "\\mingw64\\bin\\libmpg123-0.dll"), "."),
-		(os.path.join(msys64_path, "\\mingw64\\bin\\libogg-0.dll"), "."),
-		(os.path.join(msys64_path, "\\mingw64\\bin\\libopenmpt-0.dll"), "."),
-		(os.path.join(msys64_path, "\\mingw64\\bin\\libopus-0.dll"), "."),
-		(os.path.join(msys64_path, "\\mingw64\\bin\\libopusfile-0.dll"), "."),
-		(os.path.join(msys64_path, "\\mingw64\\bin\\libsamplerate-0.dll"), "."),
-		(os.path.join(msys64_path, "\\mingw64\\bin\\libvorbis-0.dll"), "."),
-		(os.path.join(msys64_path, "\\mingw64\\bin\\libvorbisfile-3.dll"), "."),
-		(os.path.join(msys64_path, "\\mingw64\\bin\\libwavpack-1.dll"), "."),
-		(os.path.join(msys64_path, "\\mingw64\\bin\\SDL2.dll"), "."),
-		(os.path.join(msys64_path, "\\mingw64\\bin\\SDL2_image.dll"), "."),
-		(os.path.join(msys64_path, "\\mingw64\\bin\\libgme.dll"), "."),
+		(str(Path(msys64_path) / "mingw64" / "bin" / "libFLAC.dll"),         "."),
+		(str(Path(msys64_path) / "mingw64" / "bin" / "libmpg123-0.dll"),     "."),
+		(str(Path(msys64_path) / "mingw64" / "bin" / "libogg-0.dll"),        "."),
+		(str(Path(msys64_path) / "mingw64" / "bin" / "libopenmpt-0.dll"),    "."),
+		(str(Path(msys64_path) / "mingw64" / "bin" / "libopus-0.dll"),       "."),
+		(str(Path(msys64_path) / "mingw64" / "bin" / "libopusfile-0.dll"),   "."),
+		(str(Path(msys64_path) / "mingw64" / "bin" / "libsamplerate-0.dll"), "."),
+		(str(Path(msys64_path) / "mingw64" / "bin" / "libvorbis-0.dll"),     "."),
+		(str(Path(msys64_path) / "mingw64" / "bin" / "libvorbisfile-3.dll"), "."),
+		(str(Path(msys64_path) / "mingw64" / "bin" / "libwavpack-1.dll"),    "."),
+		(str(Path(msys64_path) / "mingw64" / "bin" / "SDL2.dll"),            "."),
+		(str(Path(msys64_path) / "mingw64" / "bin" / "SDL2_image.dll"),      "."),
+		(str(Path(msys64_path) / "mingw64" / "bin" / "libgme.dll"),          "."),
 	],
 	datas=[],
 	hiddenimports=[

--- a/windows.spec
+++ b/windows.spec
@@ -35,7 +35,14 @@ a = Analysis(
 		(str(Path(msys64_path) / "mingw64" / "bin" / "SDL2_image.dll"),      "."),
 		(str(Path(msys64_path) / "mingw64" / "bin" / "libgme.dll"),          "."),
 	],
-	datas=[],
+	datas=[
+		("src/tauon/assets", "assets"),
+		("src/tauon/locale", "locale"),
+		("src/tauon/theme", "theme"),
+		("src/tauon/templates", "templates"),
+		# This could only have SDL2.framework and SDL2_image.framework to save space...
+		(".venv/lib/python3.12/site-packages/sdl2dll/dll", "sdl2dll/dll"),
+	]
 	hiddenimports=[
 		"infi.systray",
 		"pylast",

--- a/windows.spec
+++ b/windows.spec
@@ -44,7 +44,6 @@ a = Analysis(
 		(".venv/lib/python3.12/site-packages/sdl2dll/dll", "sdl2dll/dll"),
 	],
 	hiddenimports=[
-		"lynxtray",
 		"pylast",
 		"tekore",
 		"phazor",

--- a/windows.spec
+++ b/windows.spec
@@ -42,7 +42,7 @@ a = Analysis(
 		("src/tauon/templates", "templates"),
 		# This could only have SDL2.framework and SDL2_image.framework to save space...
 		(".venv/lib/python3.12/site-packages/sdl2dll/dll", "sdl2dll/dll"),
-	]
+	],
 	hiddenimports=[
 		"infi.systray",
 		"pylast",


### PR DESCRIPTION
Adds CI file for building Windows releases too and has some fixes for the Windows build.

Ticks a box in #1315

Fixes a leak in Phazor.

Migrates from dead infi.systray to my fork lynxtray.

A little bit of typing.

Adds missing pysdl2-dll dep to reqs.txt.

Fixes jxlpy for macOS builds.

Fix Linux builds, they were unusable due to lack of Gdk, Ayatana appindicators and librsvg. 

Bundle Plasma/GTK comaptibility libs for GTK 3.0 on Linux builds.

Make Tauon exit with a helpful error if it detects a database format newer than it knows.  
i.e. running Tauon that only knows v69 DBs against a Config directory that was created using v70, it will refuse to load and exit.  
This will obviously not work for any release pre-7.9.0, as it won't have the check.