### PR TITLE
Switch macOS CI partially away from venv and more towards brew

### DIFF
--- a/.github/workflows/build_macOS.yaml
+++ b/.github/workflows/build_macOS.yaml
@@ -98,3 +98,8 @@ jobs:
         with:
           name: TauonMusicBox-dmg
           path: dist/dmg/TauonMusicBox.dmg
+
+      - name: YOLO test run
+        run: |
+          hdiutil attach dist/dmg/TauonMusicBox.dmg
+          /Volumes/TauonMusicBox/TauonMusicBox.app/Contents/MacOS/Tauon\ Music\ Box

--- a/.github/workflows/build_macOS.yaml
+++ b/.github/workflows/build_macOS.yaml
@@ -49,34 +49,35 @@ jobs:
           export LDFLAGS="-L/opt/homebrew/lib"
           command -v python
           $(brew --prefix python)/libexec/bin/python -m pip install --break-system-packages --upgrade pip
-          $(brew --prefix python)/libexec/bin/python -m venv --system-site-packages .venv
-          source .venv/bin/activate
-          $(brew --prefix python)/libexec/bin/pip install \
+
+          $(brew --prefix python)/libexec/bin/pip install --break-system-packages \
             -r requirements.txt \
             build
           # Hack until pyinstaller has a release newer than 6.11.1 - https://github.com/pyinstaller/pyinstaller/releases
-          $(brew --prefix python)/libexec/bin/pip install https://github.com/pyinstaller/pyinstaller/archive/develop.zip
+          $(brew --prefix python)/libexec/bin/pip install --break-system-packages https://github.com/pyinstaller/pyinstaller/archive/develop.zip
+#          $(brew --prefix python)/libexec/bin/python -m venv --system-site-packages .venv
+#          source .venv/bin/activate
 #            pyinstaller
 #          CFLAGS: "-I/opt/homebrew/include"
 
       - name: Build the project using python-build
         run: |
-          source .venv/bin/activate
           $(brew --prefix python)/libexec/bin/python -m compile_translations
           $(brew --prefix python)/libexec/bin/python -m build --wheel
+#          source .venv/bin/activate
 
       - name: Install the project into a venv
         run: |
-          source .venv/bin/activate
           $(brew --prefix python)/libexec/bin/pip install --prefix ".venv" dist/*.whl
+#          source .venv/bin/activate
 
       - name: "[DEBUG] List all files"
         run: find .
 
       - name: Build macOS app with PyInstaller
         run: |
-          source .venv/bin/activate
           pyinstaller --log-level=DEBUG mac.spec
+#          source .venv/bin/activate
         env:
           DYLD_LIBRARY_PATH: "/opt/homebrew/lib"
 

--- a/.github/workflows/build_macOS.yaml
+++ b/.github/workflows/build_macOS.yaml
@@ -25,7 +25,6 @@ jobs:
       - name: Install brew dependencies
         run: |
           brew install \
-            harfbuzz \
             gobject-introspection \
             gtk+3 \
             pango \
@@ -46,8 +45,9 @@ jobs:
 
       - name: Install Python dependencies and setup venv
         run: |
+          command -v python
           python -m pip install --upgrade pip
-          python -m venv .venv
+          python -m venv --system-site-packages .venv
           source .venv/bin/activate
           export CXXFLAGS="-I/opt/homebrew/include"
           export LDFLAGS="-L/opt/homebrew/lib"

--- a/.github/workflows/build_macOS.yaml
+++ b/.github/workflows/build_macOS.yaml
@@ -39,6 +39,9 @@ jobs:
             wavpack \
             game-music-emu
 
+      - name: "[DEBUG] List all Cellar files"
+        run: find /opt/homebrew/Cellar
+
       - name: Install Python dependencies and setup venv
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/build_macOS.yaml
+++ b/.github/workflows/build_macOS.yaml
@@ -40,8 +40,8 @@ jobs:
             game-music-emu
 
 # This generates 30MB of logs, enable it only when actively debugging something
-      - name: "[DEBUG] List all Cellar files"
-        run: find /opt/homebrew/Cellar
+#      - name: "[DEBUG] List all Cellar files"
+#        run: find /opt/homebrew/Cellar
 
       - name: Install Python dependencies and setup venv
         run: |

--- a/.github/workflows/build_macOS.yaml
+++ b/.github/workflows/build_macOS.yaml
@@ -28,6 +28,7 @@ jobs:
             gobject-introspection \
             gtk+3 \
             pango \
+            pillow \
             sdl2 \
             sdl2_image \
             jpeg-xl \

--- a/.github/workflows/build_macOS.yaml
+++ b/.github/workflows/build_macOS.yaml
@@ -47,7 +47,6 @@ jobs:
         run: |
           export CXXFLAGS="-I/opt/homebrew/include"
           export LDFLAGS="-L/opt/homebrew/lib"
-          command -v python
           $(brew --prefix python)/libexec/bin/python -m pip install --break-system-packages --upgrade pip
 
           $(brew --prefix python)/libexec/bin/pip install --break-system-packages \

--- a/.github/workflows/build_macOS.yaml
+++ b/.github/workflows/build_macOS.yaml
@@ -45,30 +45,30 @@ jobs:
 
       - name: Install Python dependencies and setup venv
         run: |
-          command -v python
-          python -m pip install --upgrade pip
-          python -m venv --system-site-packages .venv
-          source .venv/bin/activate
           export CXXFLAGS="-I/opt/homebrew/include"
           export LDFLAGS="-L/opt/homebrew/lib"
-          pip install \
+          command -v python
+          $(brew --prefix python)/libexec/bin/python -m pip install --upgrade pip
+          $(brew --prefix python)/libexec/bin/python -m venv --system-site-packages .venv
+          source .venv/bin/activate
+          $(brew --prefix python)/libexec/bin/pip install \
             -r requirements.txt \
             build
           # Hack until pyinstaller has a release newer than 6.11.1 - https://github.com/pyinstaller/pyinstaller/releases
-          pip install https://github.com/pyinstaller/pyinstaller/archive/develop.zip
+          $(brew --prefix python)/libexec/bin/pip install https://github.com/pyinstaller/pyinstaller/archive/develop.zip
 #            pyinstaller
 #          CFLAGS: "-I/opt/homebrew/include"
 
       - name: Build the project using python-build
         run: |
           source .venv/bin/activate
-          python -m compile_translations
-          python -m build --wheel
+          $(brew --prefix python)/libexec/bin/python -m compile_translations
+          $(brew --prefix python)/libexec/bin/python -m build --wheel
 
       - name: Install the project into a venv
         run: |
           source .venv/bin/activate
-          pip install --prefix ".venv" dist/*.whl
+          $(brew --prefix python)/libexec/bin/pip install --prefix ".venv" dist/*.whl
 
       - name: "[DEBUG] List all files"
         run: find .

--- a/.github/workflows/build_macOS.yaml
+++ b/.github/workflows/build_macOS.yaml
@@ -25,7 +25,6 @@ jobs:
       - name: Install brew dependencies
         run: |
           brew install \
-            python \
             gobject-introspection \
             gtk+3 \
             pango \
@@ -40,8 +39,9 @@ jobs:
             wavpack \
             game-music-emu
 
-      - name: "[DEBUG] List all Cellar files"
-        run: find /opt/homebrew/Cellar
+# This generates 30MB of logs, enable it only when actively debugging something
+#      - name: "[DEBUG] List all Cellar files"
+#        run: find /opt/homebrew/Cellar
 
       - name: Install Python dependencies and setup venv
         run: |

--- a/.github/workflows/build_macOS.yaml
+++ b/.github/workflows/build_macOS.yaml
@@ -68,6 +68,7 @@ jobs:
       - name: Install the project into a venv
         run: |
           $(brew --prefix python)/libexec/bin/pip install --prefix ".venv" dist/*.whl
+#          $(brew --prefix python)/libexec/bin/pip install --break-system-packages dist/*.whl
 #          source .venv/bin/activate
 
       - name: "[DEBUG] List all files"
@@ -99,7 +100,7 @@ jobs:
           name: TauonMusicBox-dmg
           path: dist/dmg/TauonMusicBox.dmg
 
-      - name: YOLO test run
-        run: |
-          hdiutil attach dist/dmg/TauonMusicBox.dmg
-          /Volumes/TauonMusicBox/TauonMusicBox.app/Contents/MacOS/Tauon\ Music\ Box
+#      - name: Run Tauon for testing
+#        run: |
+#          hdiutil attach dist/dmg/TauonMusicBox.dmg
+#          /Volumes/TauonMusicBox/TauonMusicBox.app/Contents/MacOS/Tauon\ Music\ Box

--- a/.github/workflows/build_macOS.yaml
+++ b/.github/workflows/build_macOS.yaml
@@ -48,7 +48,7 @@ jobs:
           export CXXFLAGS="-I/opt/homebrew/include"
           export LDFLAGS="-L/opt/homebrew/lib"
           command -v python
-          $(brew --prefix python)/libexec/bin/python -m pip install --upgrade --break-system-packages pip
+          $(brew --prefix python)/libexec/bin/python -m pip --break-system-packages install --upgrade pip
           $(brew --prefix python)/libexec/bin/python -m venv --system-site-packages .venv
           source .venv/bin/activate
           $(brew --prefix python)/libexec/bin/pip install \

--- a/.github/workflows/build_macOS.yaml
+++ b/.github/workflows/build_macOS.yaml
@@ -14,10 +14,10 @@ jobs:
         with:
           submodules: true
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.13'
+#      - name: Set up Python
+#        uses: actions/setup-python@v5
+#        with:
+#          python-version: '3.13'
 
       - name: brew update and upgrade
         run: brew update && brew upgrade
@@ -25,6 +25,7 @@ jobs:
       - name: Install brew dependencies
         run: |
           brew install \
+            python \
             gobject-introspection \
             gtk+3 \
             pango \

--- a/.github/workflows/build_macOS.yaml
+++ b/.github/workflows/build_macOS.yaml
@@ -48,7 +48,7 @@ jobs:
           export CXXFLAGS="-I/opt/homebrew/include"
           export LDFLAGS="-L/opt/homebrew/lib"
           command -v python
-          $(brew --prefix python)/libexec/bin/python -m pip --break-system-packages install --upgrade pip
+          $(brew --prefix python)/libexec/bin/python -m pip install --break-system-packages --upgrade pip
           $(brew --prefix python)/libexec/bin/python -m venv --system-site-packages .venv
           source .venv/bin/activate
           $(brew --prefix python)/libexec/bin/pip install \

--- a/.github/workflows/build_macOS.yaml
+++ b/.github/workflows/build_macOS.yaml
@@ -48,7 +48,7 @@ jobs:
           export CXXFLAGS="-I/opt/homebrew/include"
           export LDFLAGS="-L/opt/homebrew/lib"
           command -v python
-          $(brew --prefix python)/libexec/bin/python -m pip install --upgrade pip
+          $(brew --prefix python)/libexec/bin/python -m pip install --upgrade --break-system-packages pip
           $(brew --prefix python)/libexec/bin/python -m venv --system-site-packages .venv
           source .venv/bin/activate
           $(brew --prefix python)/libexec/bin/pip install \

--- a/.github/workflows/build_macOS.yaml
+++ b/.github/workflows/build_macOS.yaml
@@ -25,6 +25,7 @@ jobs:
       - name: Install brew dependencies
         run: |
           brew install \
+            harfbuzz \
             gobject-introspection \
             gtk+3 \
             pango \
@@ -40,8 +41,8 @@ jobs:
             game-music-emu
 
 # This generates 30MB of logs, enable it only when actively debugging something
-#      - name: "[DEBUG] List all Cellar files"
-#        run: find /opt/homebrew/Cellar
+      - name: "[DEBUG] List all Cellar files"
+        run: find /opt/homebrew/Cellar
 
       - name: Install Python dependencies and setup venv
         run: |

--- a/extra/requirements_macos.txt
+++ b/extra/requirements_macos.txt
@@ -1,7 +1,7 @@
 beautifulsoup4
 musicbrainzngs
 mutagen
-#Pillow # Installed from brew
+Pillow
 PlexAPI
 PyGObject
 pylast>=3.1.0

--- a/extra/requirements_macos.txt
+++ b/extra/requirements_macos.txt
@@ -1,7 +1,7 @@
 beautifulsoup4
 musicbrainzngs
 mutagen
-Pillow
+#Pillow # Installed from brew
 PlexAPI
 PyGObject
 pylast>=3.1.0

--- a/mac.spec
+++ b/mac.spec
@@ -17,8 +17,6 @@ libs = [
 	"libgobject-2.0.0.dylib",
 	"libgio-2.0.0.dylib",
 	"librsvg-2.2.dylib",
-#	"libgdk-3.0.dylib",
-#	"libSDL2-2.0.0.dylib",
 ]
 
 lib_paths = [(f"{prefix}/lib/{lib}", ".") for lib in libs]

--- a/mac.spec
+++ b/mac.spec
@@ -18,6 +18,7 @@ libs = [
 	"libgio-2.0.0.dylib",
 	"librsvg-2.2.dylib",
 	"libgdk-3.0.dylib",
+	"libSDL2-2.0.0.dylib",
 ]
 
 lib_paths = [(f"{prefix}/lib/{lib}", ".") for lib in libs]

--- a/mac.spec
+++ b/mac.spec
@@ -37,7 +37,7 @@ a = Analysis(
 		("src/tauon/theme", "theme"),
 		("src/tauon/templates", "templates"),
 		# This could only have SDL2.framework and SDL2_image.framework to save space...
-		(f".venv/lib/python{python_ver}/site-packages/sdl2dll/dll", "sdl2dll/dll"),
+#		(f".venv/lib/python{python_ver}/site-packages/sdl2dll/dll", "sdl2dll/dll"),
 #		(f".venv/lib/python{python_ver}/site-packages/sdl2dll/dll/SDL2.framework", "sdl2dll/dll/SDL2.framework"),
 #		(f".venv/lib/python{python_ver}/site-packages/sdl2dll/dll/SDL2_image.framework", "sdl2dll/dll/SDL2_image.framework"),
 	],

--- a/mac.spec
+++ b/mac.spec
@@ -17,6 +17,7 @@ libs = [
 	"libgobject-2.0.0.dylib",
 	"libgio-2.0.0.dylib",
 	"librsvg-2.2.dylib",
+	"libgdk-3.0.dylib",
 ]
 
 lib_paths = [(f"{prefix}/lib/{lib}", ".") for lib in libs]

--- a/mac.spec
+++ b/mac.spec
@@ -21,7 +21,7 @@ libs = [
 ]
 
 lib_paths = [(f"{prefix}/lib/{lib}", ".") for lib in libs]
-phazor_path = f"build/lib.macosx-10.13-universal2-cpython-{python_ver_dotless}/phazor.cpython-{python_ver_dotless}-darwin.so"
+phazor_path = f"build/lib.macosx-14.0-arm64-cpython-{python_ver_dotless}/phazor.cpython-{python_ver_dotless}-darwin.so"
 
 a = Analysis(
 	["src/tauon/__main__.py"],

--- a/mac.spec
+++ b/mac.spec
@@ -17,8 +17,8 @@ libs = [
 	"libgobject-2.0.0.dylib",
 	"libgio-2.0.0.dylib",
 	"librsvg-2.2.dylib",
-	"libgdk-3.0.dylib",
-	"libSDL2-2.0.0.dylib",
+#	"libgdk-3.0.dylib",
+#	"libSDL2-2.0.0.dylib",
 ]
 
 lib_paths = [(f"{prefix}/lib/{lib}", ".") for lib in libs]
@@ -38,6 +38,7 @@ a = Analysis(
 		("src/tauon/theme", "theme"),
 		("src/tauon/templates", "templates"),
 		# This could only have SDL2.framework and SDL2_image.framework to save space...
+		(f"{prefix}/lib/python3.13/site-packages/sdl2dll/dll", "sdl2dll/dll"),
 #		(f".venv/lib/python{python_ver}/site-packages/sdl2dll/dll", "sdl2dll/dll"),
 #		(f".venv/lib/python{python_ver}/site-packages/sdl2dll/dll/SDL2.framework", "sdl2dll/dll/SDL2.framework"),
 #		(f".venv/lib/python{python_ver}/site-packages/sdl2dll/dll/SDL2_image.framework", "sdl2dll/dll/SDL2_image.framework"),

--- a/mac.spec
+++ b/mac.spec
@@ -36,7 +36,7 @@ a = Analysis(
 		("src/tauon/theme", "theme"),
 		("src/tauon/templates", "templates"),
 		# This could only have SDL2.framework and SDL2_image.framework to save space...
-		(f"{prefix}/lib/python3.13/site-packages/sdl2dll/dll", "sdl2dll/dll"),
+		(f"{prefix}/lib/python{python_ver}/site-packages/sdl2dll/dll", "sdl2dll/dll"),
 #		(f".venv/lib/python{python_ver}/site-packages/sdl2dll/dll", "sdl2dll/dll"),
 #		(f".venv/lib/python{python_ver}/site-packages/sdl2dll/dll/SDL2.framework", "sdl2dll/dll/SDL2.framework"),
 #		(f".venv/lib/python{python_ver}/site-packages/sdl2dll/dll/SDL2_image.framework", "sdl2dll/dll/SDL2_image.framework"),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 beautifulsoup4
 musicbrainzngs
 mutagen
-Pillow # ;                      sys_platform != 'darwin' # Install Pillow from brew on macOS
+#Pillow # ;                      sys_platform != 'darwin' # Install Pillow from brew on macOS
 PlexAPI
 PyGObject
 pylast>=3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 beautifulsoup4
 musicbrainzngs
 mutagen
-Pillow
+Pillow;                      sys_platform != 'darwin' # Install Pillow from brew on macOS
 PlexAPI
 PyGObject
 pylast>=3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 beautifulsoup4
 musicbrainzngs
 mutagen
-#Pillow # ;                      sys_platform != 'darwin' # Install Pillow from brew on macOS
+Pillow # ;                      sys_platform != 'darwin' # Install Pillow from brew on macOS
 PlexAPI
 PyGObject
 pylast>=3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 beautifulsoup4
 musicbrainzngs
 mutagen
-Pillow;                      sys_platform != 'darwin' # Install Pillow from brew on macOS
+Pillow # ;                      sys_platform != 'darwin' # Install Pillow from brew on macOS
 PlexAPI
 PyGObject
 pylast>=3.1.0


### PR DESCRIPTION
We were suggested to not mix and match Brew and pip to avoid issues like the one in this thread - https://github.com/orgs/pyinstaller/discussions/8974

Remove most of the venv parts and use system Python instead of GitHub one.