### PR TITLE
Improve Maloja scrobbling

### DIFF
--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -7592,7 +7592,7 @@ def maloja_get_scrobble_counts():
 	tauon.bg_save()
 
 
-def maloja_scrobble(track: TrackClass) -> bool | None:
+def maloja_scrobble(track: TrackClass, timestamp: int | None = None) -> bool | None:
 	url = prefs.maloja_url
 
 	if not track.artist or not track.title:
@@ -7603,9 +7603,20 @@ def maloja_scrobble(track: TrackClass) -> bool | None:
 			url += "/"
 		url += "apis/mlj_1/newscrobble"
 
+	if timestamp is None:
+		timestamp = int(time.time())
+
 	d = {}
-	d["artist"] = track.artist
+	d["artists"] = [track.artist] # let Maloja parse/fix artists
 	d["title"] = track.title
+
+	if len(track.album) > 0:
+		d["album"] = track.album
+	if len(track.album_artist) > 0:
+		d["albumartists"] = [track.album_artist] # let Maloja parse/fix artists
+	
+	d["length"] = int(track.length)
+	d["time"] = timestamp
 	d["key"] = prefs.maloja_key
 
 	try:
@@ -7656,7 +7667,7 @@ class LastScrob:
 				elif tr[2] == "lb" and lb.enable:
 					success = lb.listen_full(tr[0], tr[1])
 				elif tr[2] == "maloja":
-					success = maloja_scrobble(tr[0])
+					success = maloja_scrobble(tr[0], tr[1])
 				elif tr[2] == "air":
 					success = subsonic.listen(tr[0], submit=True)
 				elif tr[2] == "koel":

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -7610,9 +7610,9 @@ def maloja_scrobble(track: TrackClass, timestamp: int | None = None) -> bool | N
 	d["artists"] = [track.artist] # let Maloja parse/fix artists
 	d["title"] = track.title
 
-	if len(track.album) > 0:
+	if track.album:
 		d["album"] = track.album
-	if len(track.album_artist) > 0:
+	if track.album_artist:
 		d["albumartists"] = [track.album_artist] # let Maloja parse/fix artists
 	
 	d["length"] = int(track.length)

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -7609,7 +7609,7 @@ def maloja_scrobble(track: TrackClass) -> bool | None:
 	d["key"] = prefs.maloja_key
 
 	try:
-		r = requests.post(url, data=d, timeout=10)
+		r = requests.post(url, json=d, timeout=10)
 		if r.status_code != 200:
 			show_message(_("There was an error submitting data to Maloja server"), r.text, mode="warning")
 			return False

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -7592,7 +7592,7 @@ def maloja_get_scrobble_counts():
 	tauon.bg_save()
 
 
-def maloja_scrobble(track: TrackClass, timestamp: int | None = None) -> bool | None:
+def maloja_scrobble(track: TrackClass, timestamp: int = int(time.time())) -> bool | None:
 	url = prefs.maloja_url
 
 	if not track.artist or not track.title:
@@ -7602,9 +7602,6 @@ def maloja_scrobble(track: TrackClass, timestamp: int | None = None) -> bool | N
 		if not url.endswith("/"):
 			url += "/"
 		url += "apis/mlj_1/newscrobble"
-
-	if timestamp is None:
-		timestamp = int(time.time())
 
 	d = {}
 	d["artists"] = [track.artist] # let Maloja parse/fix artists


### PR DESCRIPTION
Improvements for the Maloja scrobbling feature.

- Sending JSON data as recommended by the [API documentation](https://github.com/krateng/maloja/blob/master/API.md#api-documentation).
- Now using the `artists` field. The old `artist` field is [still supported](https://github.com/krateng/maloja/blob/c6cf28896ca836407a1943cae5542d2b83d009cf/maloja/apis/native_v1.py#L590), but it is likely deprecated as it is not mentioned in the [documentation](https://github.com/krateng/maloja/blob/master/API.md#submitting-a-scrobble).
- Added `album`, `albumartists`, `length`, and `time` fields.