### PR TITLE
Fix getting length from libopenmpt as infinity, which could crash with Protracker modules

### DIFF
--- a/src/tauon/t_modules/t_extra.py
+++ b/src/tauon/t_modules/t_extra.py
@@ -176,8 +176,11 @@ def rm_16(line: str) -> str:
 	return line
 
 
-def get_display_time(seconds: str) -> str:
+def get_display_time(seconds: float) -> str:
 	"""Returns a string from seconds to a compact time format, e.g 2h:23"""
+	if math.isinf(seconds) or math.isnan(seconds):
+		logging.error("Infinite/NaN time passed to get_display_time()!")
+		return "∞"
 	result = divmod(int(seconds), 60)
 	if result[0] > 99:
 		result = divmod(result[0], 60)

--- a/src/tauon/t_modules/t_extra.py
+++ b/src/tauon/t_modules/t_extra.py
@@ -180,7 +180,7 @@ def get_display_time(seconds: float) -> str:
 	"""Returns a string from seconds to a compact time format, e.g 2h:23"""
 	if math.isinf(seconds) or math.isnan(seconds):
 		logging.error("Infinite/NaN time passed to get_display_time()!")
-		return "∞"
+		return "??:??"
 	result = divmod(int(seconds), 60)
 	if result[0] > 99:
 		result = divmod(result[0], 60)

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -24349,7 +24349,7 @@ def cue_scan(content: str, tn: TrackClass) -> int | None:
 			pctl.master_library[pctl.master_count] = nt
 
 			cued.append(pctl.master_count)
-			# loaded_pathes_cache[filepath.replace('\\', '/')] = pctl.master_count
+			# loaded_paths_cache[filepath.replace('\\', '/')] = pctl.master_count
 			# added.append(pctl.master_count)
 
 			pctl.master_count += 1
@@ -25707,7 +25707,7 @@ def worker1():
 	global to_get
 	global to_got
 
-	loaded_pathes_cache = {}
+	loaded_paths_cache = {}
 	loaded_cue_cache = {}
 	added = []
 
@@ -26000,7 +26000,7 @@ def worker1():
 					pctl.master_library[track.index] = track
 					if track.fullpath not in cue_list:
 						cue_list.append(track.fullpath)
-					loaded_pathes_cache[track.fullpath] = track.index
+					loaded_paths_cache[track.fullpath] = track.index
 					added.append(track.index)
 
 		except Exception:
@@ -26152,8 +26152,8 @@ def worker1():
 
 		path = path.replace("\\", "/")
 
-		if path in loaded_pathes_cache:
-			de = loaded_pathes_cache[path]
+		if path in loaded_paths_cache:
+			de = loaded_paths_cache[path]
 
 			if pctl.master_library[de].fullpath in cue_list:
 				logging.info("File has an associated .cue file... Skipping")
@@ -26628,14 +26628,14 @@ def worker1():
 					if loaderCommand == LC_Folder:
 						to_get = 0
 						to_got = 0
-						loaded_pathes_cache, loaded_cue_cache = cache_paths()
+						loaded_paths_cache, loaded_cue_cache = cache_paths()
 						# pre_get(order.target)
 						if order.force_scan:
 							gets(order.target, force_scan=True)
 						else:
 							gets(order.target)
 					elif loaderCommand == LC_File:
-						loaded_pathes_cache, loaded_cue_cache = cache_paths()
+						loaded_paths_cache, loaded_cue_cache = cache_paths()
 						add_file(order.target)
 
 					if gui.im_cancel:
@@ -33867,9 +33867,7 @@ def line_render(n_track: TrackClass, p_track: TrackClass, y, this_line_playing, 
 
 			star_x += round(70 * gui.scale)
 
-		if gui.star_mode == "star" and total > 0 and pctl.master_library[
-			index].length != 0:
-
+		if gui.star_mode == "star" and total > 0 and pctl.master_library[index].length != 0:
 			sx = width + start_x - 40 * gui.scale - offset_font_extra
 			sy = ry + (gui.playlist_row_height // 2) - (6 * gui.scale)
 			# if gui.scale == 1.25:
@@ -35103,7 +35101,7 @@ class StandardPlaylist:
 									total += 2
 								ratio = total / (n_track.length - 1)
 
-							text = str(str(int(ratio)))
+							text = str(int(ratio))
 							if text == "0":
 								text = ""
 							colour = colours.index_text


### PR DESCRIPTION
Handle passing infinity to `get_display_time()` by logging an error and parsing ??:?? back, this fixes an instant crash should we supply such a file that manages to get mangled by tag_scan() as such.

Also handle the root cause that was causing this - we were not handling a possible infinity libopenmpt can throw if it fails to parse the file length.

Upstream report - https://bugs.openmpt.org/view.php?id=1857

Also fix typing for the function and add some small touchups.

Repro broken .mod file was posted in https://discord.com/channels/687418493209018622/915799586168270878/1328664124254715934