### PR TITLE
Fix Linux CI phazor-pw

### DIFF
--- a/linux.spec
+++ b/linux.spec
@@ -26,6 +26,7 @@ a = Analysis(
 	hiddenimports=[
 		"pylast",
 		"phazor",
+		"phazor-pw",
 		# Zeroconf is hacked until this issue is resolved: https://github.com/pyinstaller/pyinstaller-hooks-contrib/issues/840
 		"zeroconf._utils.ipaddress",
 		"zeroconf._handlers.answers",

--- a/src/tauon/t_modules/t_phazor.py
+++ b/src/tauon/t_modules/t_phazor.py
@@ -95,10 +95,7 @@ def get_phazor_path(pctl: PlayerCtl) -> Path:
 	base_path = Path(pctl.install_directory).parent.parent / "build"
 
 	# Define the library name and extensions in priority order
-	if pctl.prefs.pipewire:
-		lib_name = "phazor-pw"
-	else:
-		lib_name = "phazor"
+	lib_name = "phazor-pw" if pctl.prefs.pipewire else "phazor"
 
 	extensions = [".so", ".dll", ".pyd", ".dynlib"]
 


### PR DESCRIPTION
Add phazor-pw to hidden imports to fix PipeWire on the Linux prebuilt.

Use a ternary operator in `phazor.py`