### PR TITLE
Start using Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,7 +9,9 @@ assignees: ''
 
 **Desktop (please complete the following information):**
  - OS: [e.g. Arch Linux/Windows/macOS]
- - Tauon Version [e.g. 7.9.0, see Menu->Settings->About]
+ - OS version: [e.g. rolling/11/15.2]
+ - Tauon Version: [e.g. 7.9.0, see Menu->Settings->About]
+ - Installation method: [e.g. Flatpak/OS packager/portable binary/from source]
 
 **Describe the bug**
 A clear and concise description of what the bug is.
@@ -24,8 +26,8 @@ Steps to reproduce the behavior:
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+**Screenshots/Videos**
+If applicable, add screenshots/videos to help explain your problem.
 
 **Tauon log**
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: bug
+labels: unconfirmed bug
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,68 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. Arch Linux/Windows/macOS]
+ - Tauon Version [e.g. 7.9.0, see Menu->Settings->About]
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Tauon log**
+
+<details><summary>Logfiles</summary>
+
+Python stack trace log example:
+
+```python
+Traceback (most recent call last):
+  File "/app/bin/tauon.py", line 359, in <module>
+    exec(main)
+  File "/app/bin/t_modules/t_main.py", line 4333, in <module>
+    auto_scale()
+  File "/app/bin/t_modules/t_main.py", line 4302, in auto_scale
+    prefs.scale_want = window_size[0] / logical_size[0]
+                       ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
+ZeroDivisionError: division by zero
+```
+
+Tauon log example (or attach as file):
+```log
+17:52:16 [DEBUG] Starting new HTTPS connection (1): api.listenbrainz.org:443
+17:52:16 [DEBUG] https://api.listenbrainz.org:443 "POST /1/submit-listens HTTP/1.1" 200 16
+17:52:22 [ INFO  ] Open - requested start was 0 (0)
+17:52:22 [ INFO  ] Extension: mp3
+17:52:22 [ INFO  ] After Dark -> After Dark
+17:52:22 [ INFO  ]  --- length: 259.146
+17:52:22 [ INFO  ]  --- position: 257.106
+17:52:22 [ INFO  ]  --- We are 2.0400000000000205 from end
+17:52:22 [ INFO  ] Transition gapless
+17:52:22 [ INFO  ] Submit Scrobble Mr.Kitty - After Dark
+17:52:22 [DEBUG] Starting new HTTPS connection (1): api.listenbrainz.org:443
+17:52:22 [DEBUG] https://api.listenbrainz.org:443 "POST /1/submit-listens HTTP/1.1" 200 16
+17:52:36 [ INFO  ] Auto save playtime
+```
+
+</details>
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: enhancement
+labels: proposal
 assignees: ''
 
 ---


### PR DESCRIPTION
This will help autotag issues and help users file better quality reports

New bugs automatically get `unconfirmed bug` and new feature requests the newly added `propsal` tag, the idea is to re-tag them as `bug`/`enhancement` later if they are accepted and to be able to differentiate between the two.