### PR TITLE
Start using classes for Radio playlists and stations

### DIFF
--- a/src/tauon/t_modules/t_extra.py
+++ b/src/tauon/t_modules/t_extra.py
@@ -52,7 +52,7 @@ class RadioStation:
 	country: str
 	website_url: str
 	icon: str
-	stream_url_fallback: str = ""
+	stream_url_fallback: str
 
 @dataclass
 class RadioPlaylist:

--- a/src/tauon/t_modules/t_extra.py
+++ b/src/tauon/t_modules/t_extra.py
@@ -35,7 +35,7 @@ import threading
 import time
 import urllib.parse
 import zipfile
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from gi.repository import GLib
@@ -45,6 +45,21 @@ if TYPE_CHECKING:
 
 	from tauon.t_modules.t_main import TrackClass
 
+@dataclass
+class RadioStation:
+	title: str
+	stream_url: str
+	country: str
+	website_url: str
+	icon: str
+	stream_url_fallback: str = ""
+
+@dataclass
+class RadioPlaylist:
+	uid: int
+	name: str
+	scroll: int = 0
+	stations: list[RadioStation] = field(default_factory=list)
 
 @dataclass
 class TauonQueueItem:

--- a/src/tauon/t_modules/t_extra.py
+++ b/src/tauon/t_modules/t_extra.py
@@ -47,17 +47,17 @@ if TYPE_CHECKING:
 
 @dataclass
 class RadioStation:
-	title: str
-	stream_url: str
-	country: str
-	website_url: str
-	icon: str
+	title:               str
+	stream_url:          str
+	country:             str = ""
+	website_url:         str = ""
+	icon:                str = ""
 	stream_url_fallback: str = ""
 
 @dataclass
 class RadioPlaylist:
-	uid: int
-	name: str
+	name:   str
+	uid:    int
 	scroll: int = 0
 	stations: list[RadioStation] = field(default_factory=list)
 

--- a/src/tauon/t_modules/t_extra.py
+++ b/src/tauon/t_modules/t_extra.py
@@ -52,7 +52,7 @@ class RadioStation:
 	country: str
 	website_url: str
 	icon: str
-	stream_url_fallback: str
+	stream_url_fallback: str = ""
 
 @dataclass
 class RadioPlaylist:

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -26354,8 +26354,8 @@ def load_xspf(path: str) -> None:
 		item = a[i]
 		if item["location"].startswith("http"):
 			radio = RadioStation(
-			stream_url=item["location"],
-			title=item["name"])
+				stream_url=item["location"],
+				title=item["name"])
 #			radio.scroll = 0 # TODO(Martin): This was here wrong as scrolling is meant to be for RadioPlaylist?
 			if item["info"].startswith("http"):
 				radio.website_url = item["info"]

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -18254,8 +18254,9 @@ class RadioBox:
 				if self.add_mode:
 					radio: RadioStation = RadioStation()
 				radio.title = self.radio_field_title.text
-				radio.stream_url = self.radio_field.text
-				radio.website_url = ""
+				if radio.stream_url != self.radio_field.text:
+					radio.stream_url = self.radio_field.text
+					radio.website_url = "" # Different URL, null the website # TODO(Martin): no way to edit for now
 
 				if self.add_mode:
 					pctl.radio_playlists[pctl.radio_playlist_viewing].stations.append(radio)

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -18252,7 +18252,9 @@ class RadioBox:
 			elif "http://" in self.radio_field.text or "https://" in self.radio_field.text:
 				radio = self.station_editing
 				if self.add_mode:
-					radio: RadioStation = RadioStation()
+					radio: RadioStation = RadioStation(
+						title=self.radio_field_title.text,
+						stream_url=self.radio_field.text)
 				radio.title = self.radio_field_title.text
 				if radio.stream_url != self.radio_field.text:
 					radio.stream_url = self.radio_field.text
@@ -26181,14 +26183,10 @@ def load_m3u(path: str) -> None:
 					line_title = bline.split(",", 1)[1].strip("\r\n").strip()
 
 			if line.startswith("http"):
-				radio: RadioStation = RadioStation()
-				radio.stream_url = line
-
-				if line_title:
-					radio.title = line_title
-				else:
-					radio.title = os.path.splitext(os.path.basename(path))[0].strip()
-
+				radio: RadioStation = RadioStation(
+					stream_url=line
+					title=line_title if line_title or os.path.splitext(os.path.basename(path))[0].strip()
+				)
 				stations.append(radio)
 
 				if gui.auto_play_import:

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -37278,19 +37278,19 @@ def line_render(n_track: TrackClass, p_track: TrackClass, y, this_line_playing, 
 # 	return "website_url" in prefs.radio_urls[p] and prefs.radio_urls[p].["website_url"]
 
 def visit_radio_site_deco(station: RadioStation):
-	if station.website_url is not None:
+	if station.website_url:
 		return [colours.menu_text, colours.menu_background, None]
 	return [colours.menu_text_disabled, colours.menu_background, None]
 
-def visit_radio_station_site_deco(station: RadioStation):
-	return visit_radio_site_deco(station.stream_url)
+def visit_radio_station_site_deco(item: tuple[int, RadioStation]):
+	return visit_radio_site_deco(item[1])
 
 def visit_radio_site(station: RadioStation):
-	if station.website_url is not None:
+	if station.website_url:
 		webbrowser.open(station.website_url, new=2, autoraise=True)
 
-def visit_radio_station(station: RadioStation):
-	visit_radio_site(station.stream_url)
+def visit_radio_station(item: tuple[int, RadioStation]):
+	visit_radio_site(item[1])
 
 def radio_saved_panel_test(_):
 	return radiobox.tab == 0
@@ -37567,7 +37567,7 @@ def add_station():
 	radiobox.station_editing = None
 	radiobox.center = True
 
-def rename_station(station: list[RadioStation]):
+def rename_station(item: tuple[int, RadioStation]):
 	station = item[1]
 	radiobox.active = True
 	radiobox.center = False
@@ -37577,8 +37577,8 @@ def rename_station(station: list[RadioStation]):
 	radiobox.radio_field_title.text = station.title if station.title is not None else ""
 	radiobox.station_editing = station
 
-def remove_station(stations: list[RadioStation]):
-	index = station[0]
+def remove_station(item: tuple[int, RadioStation]):
+	index = item[0]
 	del pctl.radio_playlists[pctl.radio_playlist_viewing].stations[index]
 
 def dismiss_dl():

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -66,6 +66,7 @@ import xml.etree.ElementTree as ET
 import zipfile
 from collections import OrderedDict
 from ctypes import Structure, byref, c_char_p, c_double, c_int, c_uint32, c_void_p, pointer
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -1636,8 +1637,8 @@ class PlayerCtl:
 		self.regen_in_progress = False
 		self.notify_in_progress = False
 
-		self.radio_playlists: list[RadioPlaylist] = bag.radio_playlists
-		self.radio_playlist_viewing: int = bag.radio_playlist_viewing
+		self.radio_playlists: list[RadioPlaylist] = radio_playlists
+		self.radio_playlist_viewing: int = radio_playlist_viewing
 		self.tag_history = {}
 
 		self.commit: int | None = None
@@ -23227,17 +23228,17 @@ class Undo:
 class RadioStation:
 	title: str
 	stream_url: str
-	stream_url_fallback: str
 	country: str
 	website_url: str
-	icon_url: str
+	icon: str
+	stream_url_fallback: str = ""
 
 @dataclass
 class RadioPlaylist:
 	uid: int
 	name: str
-	scroll: int
-	stations: list[RadioStation]
+	scroll: int = 0
+	stations: list[RadioStation] = field(default_factory=list)
 
 class GetSDLInput:
 
@@ -39556,7 +39557,7 @@ if (user_directory / "lyrics_substitutions.json").is_file():
 
 perf_timer.set()
 
-radio_playlists: list[RadioPlaylist] = [RadioPlayList(uid=uid_gen(), name="Default", stations=[])]
+radio_playlists: list[RadioPlaylist] = [RadioPlaylist(uid=uid_gen(), name="Default", stations=[])]
 # radio_playlists: list[dict[str, int | str | list[dict[str, str]]]]
 
 primary_stations: list[RadioStation] = []
@@ -39582,12 +39583,12 @@ primary_stations.append(RadioStation(
 	website_url="https://somafm.com/vaporwaves",
 	icon="https://somafm.com/img3/vaporwaves400.png"))
 
-rimary_stations.append(RadioStation(
-title="DKFM Shoegaze Radio",
-stream_url="https://kathy.torontocast.com:2005/stream",
-country="Canada",
-website_url="https://decayfm.com",
-icon="https://cdn-profiles.tunein.com/s193842/images/logod.png"))
+primary_stations.append(RadioStation(
+	title="DKFM Shoegaze Radio",
+	stream_url="https://kathy.torontocast.com:2005/stream",
+	country="Canada",
+	website_url="https://decayfm.com",
+	icon="https://cdn-profiles.tunein.com/s193842/images/logod.png"))
 
 for station in primary_stations:
 	radio_playlists[0].stations.append(station)

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -26184,9 +26184,8 @@ def load_m3u(path: str) -> None:
 
 			if line.startswith("http"):
 				radio: RadioStation = RadioStation(
-					stream_url=line
-					title=line_title if line_title else os.path.splitext(os.path.basename(path))[0].strip()
-				)
+					stream_url=line,
+					title=line_title if line_title else os.path.splitext(os.path.basename(path))[0].strip())
 				stations.append(radio)
 
 				if gui.auto_play_import:

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -28191,7 +28191,7 @@ def delete_playlist(index: int, force: bool = False, check_lock: bool = False) -
 	if gui.radio_view:
 		del pctl.radio_playlists[index]
 		if not pctl.radio_playlists:
-			pctl.radio_playlists = [RadioPlaylist(uid=uid_gen(),name ="Default", stations=[])]
+			pctl.radio_playlists = [RadioPlaylist(uid=uid_gen(),name="Default", stations=[])]
 		return
 
 	global default_playlist
@@ -38540,7 +38540,7 @@ def test_show_add_home_music() -> None:
 			gui.add_music_folder_ready = False
 			break
 
-def menu_is_open():
+def menu_is_open() -> bool:
 	for menu in Menu.instances:
 		if menu.active:
 			return True

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -26185,7 +26185,7 @@ def load_m3u(path: str) -> None:
 			if line.startswith("http"):
 				radio: RadioStation = RadioStation(
 					stream_url=line
-					title=line_title if line_title or os.path.splitext(os.path.basename(path))[0].strip()
+					title=line_title if line_title else os.path.splitext(os.path.basename(path))[0].strip()
 				)
 				stations.append(radio)
 

--- a/src/tauon/t_modules/t_stream.py
+++ b/src/tauon/t_modules/t_stream.py
@@ -69,18 +69,14 @@ class StreamEnc:
 		self.url = None
 
 	def stop(self) -> None:
-
-		try:
+		if self.tauon.radiobox.websocket:
 			self.tauon.radiobox.websocket.close()
 			logging.info("Websocket closed")
-		except Exception:
-			logging.exception("No socket to close?")
 
 		self.abort = True
 		self.tauon.radiobox.loaded_url = None
 
 	def start_download(self, url: str) -> bool:
-
 		self.abort = True
 		while self.download_running:
 			time.sleep(0.01)


### PR DESCRIPTION
Radio playlists used multinested list of dictionaries, converted it to classes instead.

```python
# From
radio_playlists: list[dict[str, int | str | list[dict[str, str]]]]
# To
radio_playlists: list[RadioPlaylist] 
```

* Exit if we fail to run migrations
* Requires a database bump (now 70)
* Corrects typing for RadioPlaylist variable in db_migrations
* Fixes gensokyoradio.net fallback URL (I thought I did that ages ago??)
* Stop setting scroll == 0 on Stations, it was there in one place in the code, makes no sense to me and seems like a mistake, should be set on Playlist instead?