### PR TITLE
Small CI and SDL3 fixups

### DIFF
--- a/.github/workflows/build_Windows_MINGW64.yaml
+++ b/.github/workflows/build_Windows_MINGW64.yaml
@@ -44,11 +44,11 @@ jobs:
           python -m pip install --break-system-packages --upgrade pip
           python -m venv .venv
           export CFLAGS="-I/mingw64/include"
-          export PIP_FIND_LINKS=https://github.com/ddelange/python-magic/releases/expanded_assets/0.4.28.post8
           .venv/bin/python -m pip install \
             -r requirements.txt \
             build \
             pyinstaller
+#          export PIP_FIND_LINKS=https://github.com/ddelange/python-magic/releases/expanded_assets/0.4.28.post8
 
       - name: Build the project using python-build
         shell: msys2 {0}
@@ -67,18 +67,18 @@ jobs:
       - name: Download optionals from latest release files and notofonts' GitHub
         shell: msys2 {0}
         run: |
-          curl -L -o librespot.exe  https://github.com/Taiko2k/Tauon/releases/download/v7.8.3/librespot.exe
+          curl -L -o librespot.exe  https://github.com/Taiko2k/Tauon/releases/download/v7.8.3/librespot.exe # v0.6.0 - https://github.com/librespot-org/librespot/releases
           curl -L -o TaskbarLib.tlb https://github.com/Taiko2k/Tauon/releases/download/v7.8.3/TaskbarLib.tlb
           curl -L -o TauonSMTC.dll  https://github.com/Taiko2k/Tauon/releases/download/v7.8.3/TauonSMTC.dll
           mkdir fonts
-          curl -L -o fonts/NotoSans-ExtraCondensed.ttf     https://github.com/notofonts/notofonts.github.io/raw/refs/heads/main/fonts/NotoSans/full/ttf/NotoSans-ExtraCondensed.ttf # 800KB
+          curl -L -o fonts/NotoSans-ExtraCondensed.ttf     https://github.com/notofonts/notofonts.github.io/raw/refs/heads/main/fonts/NotoSans/full/ttf/NotoSans-ExtraCondensed.ttf     # 800KB
           curl -L -o fonts/NotoSans-ExtraCondensedBold.ttf https://github.com/notofonts/notofonts.github.io/raw/refs/heads/main/fonts/NotoSans/full/ttf/NotoSans-ExtraCondensedBold.ttf # 800KB
-          curl -L -o fonts/NotoSans-Bold.ttf               https://github.com/notofonts/notofonts.github.io/raw/refs/heads/main/fonts/NotoSans/full/ttf/NotoSans-Bold.ttf # 800KB
-          curl -L -o fonts/NotoSans-Medium.ttf             https://github.com/notofonts/notofonts.github.io/raw/refs/heads/main/fonts/NotoSans/full/ttf/NotoSans-Medium.ttf # 800KB
-          curl -L -o fonts/NotoSans-Regular.ttf            https://github.com/notofonts/notofonts.github.io/raw/refs/heads/main/fonts/NotoSans/full/ttf/NotoSans-Regular.ttf # 800KB
-          curl -L -o fonts/NotoSansCJKjp-Bold.otf          https://github.com/notofonts/noto-cjk/raw/refs/heads/main/Sans/OTF/Japanese/NotoSansCJKjp-Bold.otf # 16MB
-          curl -L -o fonts/NotoSansCJKjp-Medium.otf        https://github.com/notofonts/noto-cjk/raw/refs/heads/main/Sans/OTF/Japanese/NotoSansCJKjp-Medium.otf # 16MB
-          curl -L -o fonts/NotoSansCJKjp-Regular.otf       https://github.com/notofonts/noto-cjk/raw/refs/heads/main/Sans/OTF/Japanese/NotoSansCJKjp-Regular.otf # 16MB
+          curl -L -o fonts/NotoSans-Bold.ttf               https://github.com/notofonts/notofonts.github.io/raw/refs/heads/main/fonts/NotoSans/full/ttf/NotoSans-Bold.ttf               # 800KB
+          curl -L -o fonts/NotoSans-Medium.ttf             https://github.com/notofonts/notofonts.github.io/raw/refs/heads/main/fonts/NotoSans/full/ttf/NotoSans-Medium.ttf             # 800KB
+          curl -L -o fonts/NotoSans-Regular.ttf            https://github.com/notofonts/notofonts.github.io/raw/refs/heads/main/fonts/NotoSans/full/ttf/NotoSans-Regular.ttf            # 800KB
+          curl -L -o fonts/NotoSansCJKjp-Bold.otf          https://github.com/notofonts/noto-cjk/raw/refs/heads/main/Sans/OTF/Japanese/NotoSansCJKjp-Bold.otf                           # 16MB
+          curl -L -o fonts/NotoSansCJKjp-Medium.otf        https://github.com/notofonts/noto-cjk/raw/refs/heads/main/Sans/OTF/Japanese/NotoSansCJKjp-Medium.otf                         # 16MB
+          curl -L -o fonts/NotoSansCJKjp-Regular.otf       https://github.com/notofonts/noto-cjk/raw/refs/heads/main/Sans/OTF/Japanese/NotoSansCJKjp-Regular.otf                        # 16MB
 
       - name: "[DEBUG] List all files"
         shell: msys2 {0}

--- a/.github/workflows/build_macOS.yaml
+++ b/.github/workflows/build_macOS.yaml
@@ -30,6 +30,7 @@ jobs:
             pango \
             pillow \
             sdl3 \
+            sdl3_image \
             jpeg-xl \
             ffmpeg \
             librsvg \
@@ -37,7 +38,6 @@ jobs:
             libopenmpt \
             wavpack \
             game-music-emu
-#            sdl2_image \
 
 # This generates 30MB of logs, enable it only when actively debugging something
 #      - name: "[DEBUG] List all Cellar files"

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
   - Fast, comfortable and responsive UI.
   - Support for **gapless playback**.
   - Import tracks and create playlists by simple **drag and drop**.
-  - Supports most common codecs and tracker file types.  
-  - Seamless support for CUE sheets. 
+  - Supports most common codecs and tracker file types.
+  - Seamless support for CUE sheets.
   - Stream music from your **PLEX**, **Jellyfin** or **Airsonic** server.
   - Import and play your **Spotify** library.
   - Large album art and gallery browsing!
@@ -36,7 +36,7 @@ Installation is available as a Flatpak.
 
 <a href='https://flathub.org/apps/details/com.github.taiko2k.tauonmb'><img width='240' alt='Download on Flathub' src='https://dl.flathub.org/assets/badges/flathub-badge-en.png'/></a>
 
-Flatpak uses sandboxing, see [here](https://github.com/Taiko2k/TauonMusicBox/wiki/Sandboxing-Quirks) for notes. 
+Flatpak uses sandboxing, see [here](https://github.com/Taiko2k/TauonMusicBox/wiki/Sandboxing-Quirks) for notes.
 
 You can also install from the [AUR](https://aur.archlinux.org/packages/tauon-music-box/) on **Arch Linux** based distros.
 
@@ -53,6 +53,4 @@ I highly recommend reading the Tauon [manual](https://tauonmusicbox.rocks#manual
 
 Feel free to submit any issues you encounter.
 
-[![Maintenance](https://img.shields.io/maintenance/yes/2024.svg?color=a3e11f&style=for-the-badge)](https://github.com/Taiko2k/tauonmb/releases) [![GitHub release](https://img.shields.io/github/release/taiko2k/tauonmb.svg?style=for-the-badge&colorB=ff69b4)](https://github.com/Taiko2k/tauonmb/releases) ![Platform](https://img.shields.io/badge/platform-linux-lightgrey.svg?style=for-the-badge) [![Discord](https://img.shields.io/discord/687418493209018622.svg?color=a483ef&style=for-the-badge)](https://discord.gg/v4EmhES)
-
-
+[![Maintenance](https://img.shields.io/maintenance/yes/2025.svg?color=a3e11f&style=for-the-badge)](https://github.com/Taiko2k/tauonmb/releases) [![GitHub release](https://img.shields.io/github/release/taiko2k/tauonmb.svg?style=for-the-badge&colorB=ff69b4)](https://github.com/Taiko2k/tauonmb/releases) ![Platform](https://img.shields.io/badge/platform-linux-lightgrey.svg?style=for-the-badge) [![Discord](https://img.shields.io/discord/687418493209018622.svg?color=a483ef&style=for-the-badge)](https://discord.gg/v4EmhES)

--- a/extra/msyspac.txt
+++ b/extra/msyspac.txt
@@ -17,4 +17,5 @@ mingw-w64-x86_64-python-websocket-client
 mingw-w64-x86_64-rust
 mingw-w64-x86_64-sdl3
 mingw-w64-x86_64-sdl3-image
+mingw-w64-x86_64-sdl3-ttf
 mingw-w64-x86_64-wavpack

--- a/extra/msyspac.txt
+++ b/extra/msyspac.txt
@@ -15,6 +15,6 @@ mingw-w64-x86_64-python-pillow
 mingw-w64-x86_64-python-pip
 mingw-w64-x86_64-python-websocket-client
 mingw-w64-x86_64-rust
-mingw-w64-x86_64-SDL2
-mingw-w64-x86_64-SDL2_image
+mingw-w64-x86_64-sdl3
+mingw-w64-x86_64-sdl3-image
 mingw-w64-x86_64-wavpack

--- a/extra/requirements_linux.txt
+++ b/extra/requirements_linux.txt
@@ -7,7 +7,6 @@ PlexAPI
 PyGObject
 pylast>=3.1.0
 PySDL3
-#pysdl3-dll
 requests
 Send2Trash
 unidecode

--- a/extra/requirements_macos.txt
+++ b/extra/requirements_macos.txt
@@ -6,7 +6,6 @@ PlexAPI
 PyGObject
 pylast>=3.1.0
 PySDL3
-#pysdl3-dll
 requests
 Send2Trash
 unidecode

--- a/extra/requirements_windows.txt
+++ b/extra/requirements_windows.txt
@@ -10,7 +10,6 @@ PyGObject
 pyinstaller
 pylast>=3.1.0
 PySDL3
-#pysdl3-dll
 requests
 Send2Trash
 unidecode

--- a/linux.spec
+++ b/linux.spec
@@ -18,10 +18,6 @@ a = Analysis(
 		("src/tauon/locale", "locale"),
 		("src/tauon/theme", "theme"),
 		("src/tauon/templates", "templates"),
-		# This could only have SDL3.framework and SDL3_image.framework to save space...
-#		(f".venv/lib/python{python_ver}/site-packages/sdl2dll/dll", "sdl2dll/dll"),
-#		(f".venv/lib/python{python_ver}/site-packages/sdl2dll/dll/SDL2.framework", "sdl2dll/dll/SDL2.framework"),
-#		(f".venv/lib/python{python_ver}/site-packages/sdl2dll/dll/SDL2_image.framework", "sdl2dll/dll/SDL2_image.framework"),
 	],
 	hiddenimports=[
 		"pylast",

--- a/linux.spec
+++ b/linux.spec
@@ -18,7 +18,7 @@ a = Analysis(
 		("src/tauon/locale", "locale"),
 		("src/tauon/theme", "theme"),
 		("src/tauon/templates", "templates"),
-		# This could only have SDL2.framework and SDL2_image.framework to save space...
+		# This could only have SDL3.framework and SDL3_image.framework to save space...
 #		(f".venv/lib/python{python_ver}/site-packages/sdl2dll/dll", "sdl2dll/dll"),
 #		(f".venv/lib/python{python_ver}/site-packages/sdl2dll/dll/SDL2.framework", "sdl2dll/dll/SDL2.framework"),
 #		(f".venv/lib/python{python_ver}/site-packages/sdl2dll/dll/SDL2_image.framework", "sdl2dll/dll/SDL2_image.framework"),

--- a/mac.spec
+++ b/mac.spec
@@ -35,11 +35,6 @@ a = Analysis(
 		("src/tauon/locale", "locale"),
 		("src/tauon/theme", "theme"),
 		("src/tauon/templates", "templates"),
-		# This could only have SDL3.framework and SDL3_image.framework to save space...
-#		(f"{prefix}/lib/python{python_ver}/site-packages/sdl3dll/dll", "sdl3dll/dll"),
-#		(f".venv/lib/python{python_ver}/site-packages/sdl3dll/dll", "sdl3dll/dll"),
-#		(f".venv/lib/python{python_ver}/site-packages/sdl3dll/dll/SDL3.framework", "sdl3dll/dll/SDL3.framework"),
-#		(f".venv/lib/python{python_ver}/site-packages/sdl3dll/dll/SDL3_image.framework", "sdl3dll/dll/SDL3_image.framework"),
 	],
 	hiddenimports=[
 		"sdl3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,12 +18,12 @@
 #		"PlexAPI", # OPTDEP
 #		"PyGObject",
 #		"pylast>=3.1.0",
-#		"PySDL2",
+#		"PySDL3",
 #		"requests",
 #		"Send2Trash",
 #		"unidecode",
 #		"dbus-python;                 sys_platform == 'linux'",
-#		"pysdl2-dll;                  sys_platform == 'darwin'", # Don't rely on system https://github.com/py-sdl/py-sdl2#requirements
+#		"pysdl3-dll;                  sys_platform == 'darwin'", # Don't rely on system https://github.com/Aermoss/PySDL3
 #		"comtypes;                    sys_platform == 'win32'",
 #		"lynxtray;                    sys_platform == 'win32'",
 #		"keyboard;                    sys_platform == 'win32'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@
 #		"Send2Trash",
 #		"unidecode",
 #		"dbus-python;                 sys_platform == 'linux'",
-#		"pysdl3-dll;                  sys_platform == 'darwin'", # Don't rely on system https://github.com/Aermoss/PySDL3
 #		"comtypes;                    sys_platform == 'win32'",
 #		"lynxtray;                    sys_platform == 'win32'",
 #		"keyboard;                    sys_platform == 'win32'",

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ PlexAPI
 PyGObject
 pylast>=3.1.0
 PySDL3
-#pysdl3-dll # Don't rely on system SDL2 https://github.com/py-sdl/py-sdl2#requirements
 #python-magic # optional
 requests
 Send2Trash

--- a/src/tauon/__main__.py
+++ b/src/tauon/__main__.py
@@ -199,7 +199,7 @@ if d in ["GNOME:Phosh"]:
 	phone = True
 
 if pyinstaller_mode: # and sys.platform == 'darwin':
-	os.environ["PYSDL2_DLL_PATH"] = str(install_directory)
+	os.environ["SDL_BINARY_PATH"] = str(install_directory)
 
 fs_mode = False
 if os.environ.get("GAMESCOPE_WAYLAND_DISPLAY") is not None:

--- a/src/tauon/__main__.py
+++ b/src/tauon/__main__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Tauon Music Box"""
 
-# Copyright © 2015-2024, Taiko2k captain(dot)gxj(at)gmail.com
+# Copyright © 2015-2025, Taiko2k captain(dot)gxj(at)gmail.com
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -8,7 +8,7 @@ written some things terribly wrong or inefficiently in places.
 I would highly recommend not using this project as an example on how to code cleanly or correctly.
 """
 
-# Copyright © 2015-2024, Taiko2k captain(dot)gxj(at)gmail.com
+# Copyright © 2015-2025, Taiko2k captain(dot)gxj(at)gmail.com
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -12288,7 +12288,7 @@ class Over:
 
 			ddt.text((x, y - 6 * gui.scale), t_version, colours.box_text_label, 313)
 			y += 19 * gui.scale
-			ddt.text((x, y), "Copyright © 2015-2024 Taiko2k captain.gxj@gmail.com", colours.box_sub_text, 13)
+			ddt.text((x, y), "Copyright © 2015-2025 Taiko2k captain.gxj@gmail.com", colours.box_sub_text, 13)
 
 			y += 19 * gui.scale
 			link_pa = draw_linked_text(

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -12382,10 +12382,10 @@ class Over:
 			font = 12
 			spacing = round(18 * gui.scale)
 			y += spacing
-			ddt.text((x, y), "PySDL2", colours.box_sub_text, font)
+			ddt.text((x, y), "PySDL3", colours.box_sub_text, font)
 			ddt.text((xx, y), _("Public Domain"), colours.box_text_label, font)
 			draw_linked_text2(
-				xxx, y, "https://github.com/marcusva/py-sdl2", colours.box_sub_text, font, click=self.click, replace="github")
+				xxx, y, "https://github.com/Aermoss/PySDL3", colours.box_sub_text, font, click=self.click, replace="github")
 
 			y += spacing
 			ddt.text((x, y), "Tekore", colours.box_sub_text, font)
@@ -39022,7 +39022,7 @@ except Exception:
 # ------------------------------------------------
 
 if system == "Windows":
-	os.environ["PYSDL2_DLL_PATH"] = str(install_directory / "lib")
+	os.environ["SDL_BINARY_PATH"] = str(install_directory / "lib")
 elif not msys and not macos:
 	try:
 		gi.require_version("Notify", "0.7")

--- a/windows.spec
+++ b/windows.spec
@@ -35,8 +35,8 @@ a = Analysis(
 		(str(Path(msys64_path) / "mingw64" / "bin" / "libvorbis-0.dll"),     "."),
 		(str(Path(msys64_path) / "mingw64" / "bin" / "libvorbisfile-3.dll"), "."),
 		(str(Path(msys64_path) / "mingw64" / "bin" / "libwavpack-1.dll"),    "."),
-		(str(Path(msys64_path) / "mingw64" / "bin" / "SDL2.dll"),            "."),
-		(str(Path(msys64_path) / "mingw64" / "bin" / "SDL2_image.dll"),      "."),
+		(str(Path(msys64_path) / "mingw64" / "bin" / "SDL3.dll"),            "."),
+		(str(Path(msys64_path) / "mingw64" / "bin" / "SDL3_image.dll"),      "."),
 	],
 	datas=[
 		(certifi.where(), "certifi"),
@@ -48,7 +48,7 @@ a = Analysis(
 		("librespot.exe", "."),
 		("TaskbarLib.tlb", "."),
 		("TauonSMTC.dll", "lib"),
-		# This could only have SDL2.framework and SDL2_image.framework to save space...
+		# This could only have SDL3.framework and SDL3_image.framework to save space...
 #		(f".venv/lib/python{python_ver}/site-packages/sdl2dll/dll", "sdl2dll/dll"),
 	],
 	hiddenimports=[

--- a/windows.spec
+++ b/windows.spec
@@ -37,6 +37,7 @@ a = Analysis(
 		(str(Path(msys64_path) / "mingw64" / "bin" / "libwavpack-1.dll"),    "."),
 		(str(Path(msys64_path) / "mingw64" / "bin" / "SDL3.dll"),            "."),
 		(str(Path(msys64_path) / "mingw64" / "bin" / "SDL3_image.dll"),      "."),
+		(str(Path(msys64_path) / "mingw64" / "bin" / "SDL3_ttf.dll"),      "."),
 	],
 	datas=[
 		(certifi.where(), "certifi"),

--- a/windows.spec
+++ b/windows.spec
@@ -49,8 +49,6 @@ a = Analysis(
 		("librespot.exe", "."),
 		("TaskbarLib.tlb", "."),
 		("TauonSMTC.dll", "lib"),
-		# This could only have SDL3.framework and SDL3_image.framework to save space...
-#		(f".venv/lib/python{python_ver}/site-packages/sdl2dll/dll", "sdl2dll/dll"),
 	],
 	hiddenimports=[
 		"pylast",


### PR DESCRIPTION
Both brew and msys now ship sdl3 and sdl3_image.

Windows seems to need sdl3_ttf too, or at least the launch fails without it on a crc checksum failure when it tries to download it...

the pysdl env var seems to have been renamed - https://pysdl3.readthedocs.io/en/latest/install.html#custom-binaries

EDIT: Actually it looks like pysdl3 will always download all missing libraries without overrides and requires all extra SDL libraries anyways - raised [here](https://github.com/Aermoss/PySDL3/issues/15)

This is great on Linux where we don't have the libraries shipped on 24.04 Ubuntu that we build from, not so much on Windows/macOS.