### PR TITLE
Convert Prefs to a dataclass

### DIFF
--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -1384,6 +1384,7 @@ class PlayerCtl:
 		# Playback
 
 		self.track_queue = track_queue
+		self.default_playlist: list[int] = []
 		self.queue_step = playing_in_queue
 		self.playing_time = 0
 		self.playlist_playing_position = playlist_playing  # track in playlist that is playing
@@ -28038,7 +28039,7 @@ def move_playlist(source, dest):
 
 		pctl.active_playlist_playing = pctl.multi_playlist.index(active)
 		pctl.active_playlist_viewing = pctl.multi_playlist.index(view)
-		default_playlist = default_playlist = pctl.multi_playlist[pctl.active_playlist_viewing].playlist_ids
+		default_playlist = pctl.multi_playlist[pctl.active_playlist_viewing].playlist_ids
 	except Exception:
 		logging.exception("Playlist move error")
 
@@ -39264,8 +39265,6 @@ repeat_mode = False
 
 notify_change = lambda: None
 
-multi_playlist: list[TauonPlaylist] = [pl_gen()]
-default_playlist: list[int] = multi_playlist[0].playlist_ids
 playlist_active: int = 0
 
 quick_search_mode = False
@@ -39303,21 +39302,41 @@ latest_db_version: float = 70
 albums = []
 album_position = 0
 
+force_subpixel_text = False
+if gtk_settings and gtk_settings.get_property("gtk-xft-rgba") == "rgb":
+	force_subpixel_text = True
+dc_device = False  # (BASS) Disconnect device on pause
+if desktop == "KDE":
+	dc_device = True
+encoder_output = music_directory / "encode-output"
+if music_directory is None:
+	encoder_output = user_directory / "encoder"
+power_save = False
+if macos or phone:
+	power_save = True
+
+multi_playlist: list[TauonPlaylist] = [pl_gen()]
 prefs = Prefs(
-	user_directory=user_directory,
-	music_directory=music_directory,
-	cache_directory=cache_directory,
+	power_save=power_save,
+	encoder_output=encoder_output,
+#	user_directory=user_directory,
+#	music_directory=music_directory,
+#	cache_directory=cache_directory,
+	force_subpixel_text=force_subpixel_text,
+	dc_device=dc_device,
 	macos=macos,
+#	detect_macstyle=detect_macstyle,
+	macstyle=macos or detect_macstyle,
+	left_window_control=macos or left_window_control,
 	phone=phone,
-	left_window_control=left_window_control,
-	detect_macstyle=detect_macstyle,
-	gtk_settings=gtk_settings,
+#	gtk_settings=gtk_settings,
 	discord_allow=discord_allow,
 	flatpak_mode=flatpak_mode,
 	desktop=desktop,
 	window_opacity=window_opacity,
-	scale=scale,
+	ui_scale=scale,
 )
+prefs.theme = get_theme_number(prefs.theme_name)
 
 gui = GuiVar()
 star_store = StarStore()
@@ -40061,6 +40080,8 @@ except Exception:
 	logging.exception("Cannot find libgme")
 
 pctl = PlayerCtl()
+pctl.default_playlist = multi_playlist[0].playlist_ids
+default_playlist = pctl.default_playlist
 
 notify_change = pctl.notify_change
 

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -39265,6 +39265,8 @@ repeat_mode = False
 
 notify_change = lambda: None
 
+multi_playlist: list[TauonPlaylist] = [pl_gen()]
+default_playlist: list[int] = multi_playlist[0].playlist_ids
 playlist_active: int = 0
 
 quick_search_mode = False
@@ -40080,8 +40082,7 @@ except Exception:
 	logging.exception("Cannot find libgme")
 
 pctl = PlayerCtl()
-pctl.default_playlist = multi_playlist[0].playlist_ids
-default_playlist = pctl.default_playlist
+pctl.default_playlist = default_playlist
 
 notify_change = pctl.notify_change
 

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -39317,7 +39317,6 @@ power_save = False
 if macos or phone:
 	power_save = True
 
-multi_playlist: list[TauonPlaylist] = [pl_gen()]
 prefs = Prefs(
 	power_save=power_save,
 	encoder_output=encoder_output,

--- a/src/tauon/t_modules/t_prefs.py
+++ b/src/tauon/t_modules/t_prefs.py
@@ -1,426 +1,408 @@
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
 	from pathlib import Path
 
-	import gi
-	gi.require_version("Gtk", "3.0")
-	from gi.repository import Gtk
-
+@dataclass
 class Prefs:
 	"""Used to hold any kind of settings"""
 
-	def __init__(
-		self, *, user_directory: Path, music_directory: Path | None, cache_directory: Path,
-		macos: bool, phone: bool, left_window_control: bool, detect_macstyle: bool,
-		gtk_settings: Gtk.Settings | None, discord_allow: bool,
-		flatpak_mode: bool, desktop: str | None, window_opacity: float, scale: float,
-	) -> None:
-		self.colour_from_image:       bool = False
-		self.dim_art:                 bool = False
-		self.prefer_side:             bool = True  # Saves whether side panel is shown or not
-		self.pause_fade_time:          int = 400
-		self.change_volume_fade_time:  int = 400
-		self.cross_fade_time:          int = 700
-		self.volume_wheel_increment:   int = 2
-		self.encoder_output:          Path = user_directory / "encoder"
-		if music_directory is not None:
-			self.encoder_output:        Path = music_directory / "encode-output"
-		self.rename_folder_template:   str = "<albumartist> - <album>"
-		self.rename_tracks_template:   str = "<tn>. <artist> - <title>.<ext>"
-
-		self.enable_web:   bool = False
-		self.allow_remote: bool = False
-		self.expose_web:   bool = True
-
-		self.enable_transcode:    bool = True
-		self.show_rym:            bool = False
-		self.show_band:           bool = False
-		self.show_wiki:           bool = False
-		self.show_transfer:       bool = True
-		self.show_queue:          bool = True
-		self.prefer_bottom_title: bool = True
-		self.append_date:         bool = True
-
-		self.transcode_codec:   str = "opus"
-		self.transcode_mode:    str = "single"
-		self.transcode_bitrate: int = 64
-
-		# self.line_style: int = 1
-		self.device:      int = 1
-		self.device_name: str = ""
-
-		self.cache_gallery:           bool = True
-		self.gallery_row_scroll:      bool = True
-		self.gallery_scroll_wheel_px: int = 90
-
-		self.playlist_font_size:  int = 15
-		self.playlist_row_height: int = 27
-
-		self.tag_editor_name:   str = ""
-		self.tag_editor_target: str = ""
-		self.tag_editor_path:   str = ""
+#	music_directory:         Path | None
+	encoder_output:          Path
+#	user_directory:          Path
+#	cache_directory:         Path
+	window_opacity:          float
+	ui_scale:                float
+	power_save:              bool
+	flatpak_mode:            bool
+	discord_allow:           bool
+	left_window_control:     bool
+	macstyle:                bool
+	macos:                   bool
+	phone:                   bool
+	force_subpixel_text:     bool
+	dc_device:               bool
+	desktop:                 str
+	album_mode:              bool = False
+	colour_from_image:       bool = False
+	dim_art:                 bool = False
+	prefer_side:             bool = True  # Saves whether side panel is shown or not
+	pause_fade_time:          int = 400
+	change_volume_fade_time:  int = 400
+	cross_fade_time:          int = 700
+	volume_wheel_increment:   int = 2
+	rename_folder_template:   str = "<albumartist> - <album>"
+	rename_tracks_template:   str = "<tn>. <artist> - <title>.<ext>"
+
+	enable_web:   bool = False
+	allow_remote: bool = False
+	expose_web:   bool = True
+
+	enable_transcode:    bool = True
+	show_rym:            bool = False
+	show_band:           bool = False
+	show_wiki:           bool = False
+	show_transfer:       bool = True
+	show_queue:          bool = True
+	prefer_bottom_title: bool = True
+	append_date:         bool = True
+
+	transcode_codec:   str = "opus"
+	transcode_mode:    str = "single"
+	transcode_bitrate: int = 64
+
+	#line_style: int = 1
+	device:      int = 1
+	device_name: str = ""
+
+	cache_gallery:           bool = True
+	gallery_row_scroll:      bool = True
+	gallery_scroll_wheel_px: int = 90
+
+	playlist_font_size:  int = 15
+	playlist_row_height: int = 27
+
+	tag_editor_name:   str = ""
+	tag_editor_target: str = ""
+	tag_editor_path:   str = ""
+
+	use_title:    bool = False
+	auto_extract: bool = False
+	auto_del_zip: bool = False
+	pl_thumb:     bool = False
+
+	use_custom_fonts:          bool = False
+	linux_font:                str = "Noto Sans, Noto Sans CJK JP, Arial,"
+	linux_font_semibold:       str = "Noto Sans, Noto Sans CJK JP, Arial, Medium"
+	linux_font_bold:           str = "Noto Sans, Noto Sans CJK JP, Bold"
+	linux_font_condensed:      str = "Noto Sans, Extra-Condensed"
+	linux_font_condensed_bold: str = "Noto Sans, Extra-Condensed Bold"
+
+	spec2_scroll: bool = True
 
-		self.use_title:    bool = False
-		self.auto_extract: bool = False
-		self.auto_del_zip: bool = False
-		self.pl_thumb:     bool = False
+	spec2_p_base:     list[float] = field(default_factory=lambda: [10, 10, 100])
+	spec2_p_multiply: list[float] = field(default_factory=lambda: [0.5, 1, 1])
 
-		self.use_custom_fonts:          bool = False
-		self.linux_font:                str = "Noto Sans, Noto Sans CJK JP, Arial,"
-		self.linux_font_semibold:       str = "Noto Sans, Noto Sans CJK JP, Arial, Medium"
-		self.linux_font_bold:           str = "Noto Sans, Noto Sans CJK JP, Bold"
-		self.linux_font_condensed:      str = "Noto Sans, Extra-Condensed"
-		self.linux_font_condensed_bold: str = "Noto Sans, Extra-Condensed Bold"
+	spec2_base:           list[float] = field(default_factory=lambda: [10, 10, 100])
+	spec2_multiply:       list[float] = field(default_factory=lambda: [0.5, 1, 1])
+	spec2_colour_setting: str = "custom"
 
-		self.spec2_scroll: bool = True
+	auto_lfm:      bool = False
+	scrobble_mark: bool = False
+	enable_mpris:  bool = True
 
-		self.spec2_p_base:     list[float] = [10, 10, 100]
-		self.spec2_p_multiply: list[float] = [0.5, 1, 1]
+	replay_gain:       int  = 0  # 0=off 1=track 2=album
+	replay_preamp:     int  = 0  # db
+	radio_page_lyrics: bool = True
 
-		self.spec2_base:           list[float] = [10, 10, 100]
-		self.spec2_multiply:       list[float] = [0.5, 1, 1]
-		self.spec2_colour_setting: str = "custom"
+	show_gimage:      bool = False
+	end_setting:      str  = "stop"
+	show_gen:         bool = False
+	show_lyrics_side: bool = True
 
-		self.auto_lfm:      bool = False
-		self.scrobble_mark: bool = False
-		self.enable_mpris:  bool = True
+	log_vol: bool = False
 
-		self.replay_gain:       int  = 0  # 0=off 1=track 2=album
-		self.replay_preamp:     int  = 0  # db
-		self.radio_page_lyrics: bool = True
+	transcode_opus_as: bool = False
 
-		self.show_gimage:      bool = False
-		self.end_setting:      str  = "stop"
-		self.show_gen:         bool = False
-		self.show_lyrics_side: bool = True
+	discord_active:     bool = False
+	discord_ready:      bool = False
+	disconnect_discord: bool = False
 
-		self.log_vol: bool = False
+	monitor_downloads: bool = True
+	extract_to_music:  bool = False
 
-		self.ui_scale: float = scale
+	enable_lb: bool = False
+	lb_token:  str  = ""
 
-		# if flatpak_mode:
+	use_jump_crossfade:       bool = True
+	use_transition_crossfade: bool = False
+	use_pause_fade:           bool = True
 
-		self.transcode_opus_as: bool = False
+	show_notifications: bool = True
 
-		self.discord_active:     bool = False
-		self.discord_ready:      bool = False
-		self.disconnect_discord: bool = False
+	true_shuffle:      bool = True
+	append_total_time: bool = False
+	backend:           int  = 4  # 2 gstreamer, 4 phazor
 
-		self.monitor_downloads: bool = True
-		self.extract_to_music:  bool = False
+	album_repeat_mode:  bool = False  # passed to pctl
+	album_shuffle_mode: bool = False  # passed to pctl
 
-		self.enable_lb: bool = False
-		self.lb_token:  str  = ""
+	finish_current: bool = False  # Finish current album when adding to queue
 
-		self.use_jump_crossfade:       bool = True
-		self.use_transition_crossfade: bool = False
-		self.use_pause_fade:           bool = True
+	reload_play_state: bool = False  # Resume playback on app restart
+	resume_play_wake:  bool = False  # Resume playback on wake
+	reload_state: tuple[int, float] | None = None
 
-		self.show_notifications: bool = True
+	mono: bool = False
 
-		self.true_shuffle:      bool = True
-		self.append_total_time: bool = False
-		self.backend:           int  = 4  # 2 gstreamer, 4 phazor
+	last_fm_token = None
+	last_fm_username = ""
 
-		self.album_repeat_mode:  bool = False  # passed to pctl
-		self.album_shuffle_mode: bool = False  # passed to pctl
+	use_card_style = True
 
-		self.finish_current: bool = False  # Finish current album when adding to queue
+	plex_username = ""
+	plex_password = ""
+	plex_servername = ""
 
-		self.reload_play_state: bool = False  # Resume playback on app restart
-		self.resume_play_wake:  bool = False  # Resume playback on wake
-		self.reload_state: tuple[int, float] | None = None
+	koel_username = "admin@example.com"
+	koel_password = "admin"
+	koel_server_url = "http://localhost:8050"
 
-		self.mono: bool = False
+	auto_lyrics = False  # Function has been disabled
+	jelly_username = ""
+	jelly_password = ""
+	jelly_server_url = "http://localhost:8096"
 
-		self.last_fm_token = None
-		self.last_fm_username = ""
+	auto_lyrics_checked: list = field(default_factory=list)
 
-		self.use_card_style = True
+	show_side_art = True
+	always_pin_playlists = True
 
-		self.plex_username = ""
-		self.plex_password = ""
-		self.plex_servername = ""
+	gallery_single_click = True
+	custom_bg_opacity = 40
 
-		self.koel_username = "admin@example.com"
-		self.koel_password = "admin"
-		self.koel_server_url = "http://localhost:8050"
+	tabs_on_top = True
 
-		self.auto_lyrics = False  # Function has been disabled
-		self.jelly_username = ""
-		self.jelly_password = ""
-		self.jelly_server_url = "http://localhost:8096"
+	showcase_vis = True
+	show_lyrics_showcase = True
 
-		self.auto_lyrics_checked = []
+	spec2_colour_mode = 0
 
-		self.show_side_art = True
-		self.always_pin_playlists = True
+	device_buffer = 80
 
-		self.user_directory:  Path = user_directory
-		self.cache_directory: Path = cache_directory
+	eq = [0.0] * 10
+	use_eq = False
 
-		self.window_opacity = window_opacity
-		self.gallery_single_click = True
-		self.custom_bg_opacity = 40
+	bio_large = False
+	discord_show = False
 
-		self.tabs_on_top = True
-		self.desktop = desktop
+	min_to_tray = False
 
-		self.dc_device = False  # (BASS) Disconnect device on pause
-		if desktop == "KDE":
-			self.dc_device = True
+	guitar_chords = False
+	prefer_synced_lyrics = True
+	sync_lyrics_time_offset = 0
 
-		self.showcase_vis = True
-		self.show_lyrics_showcase = True
+	playback_follow_cursor = False
+	short_buffer = False
 
-		self.spec2_colour_mode = 0
-		self.flatpak_mode = flatpak_mode
+	gst_output = "rgvolume pre-amp=-2 fallback-gain=-6 ! autoaudiosink"
 
-		self.device_buffer = 80
+	art_bg = False
+	art_bg_stronger = 1
+	art_bg_opacity = 10
+	art_bg_blur = 9
+	art_bg_always_blur = False
 
-		self.eq = [0.0] * 10
-		self.use_eq = False
+	random_mode = False
+	repeat_mode = False
 
-		self.bio_large = False
-		self.discord_allow = discord_allow
-		self.discord_show = False
+	failed_artists: list = field(default_factory=list)
+	failed_background_artists: list = field(default_factory=list)
 
-		self.min_to_tray = False
+	artist_list = False
+	auto_sort = False
 
-		self.guitar_chords = False
-		self.prefer_synced_lyrics = True
-		self.sync_lyrics_time_offset = 0
+	transcode_inplace = False
 
-		self.playback_follow_cursor = False
-		self.short_buffer = False
+	bg_showcase_only = False
 
-		self.gst_output = "rgvolume pre-amp=-2 fallback-gain=-6 ! autoaudiosink"
+	lyrics_enables: list = field(default_factory=list)
 
-		self.art_bg = False
-		self.art_bg_stronger = 1
-		self.art_bg_opacity = 10
-		self.art_bg_blur = 9
-		self.art_bg_always_blur = False
+	fatvap = "6b2a9499238ce6416783fc8129b8ac67"
 
-		self.random_mode = False
-		self.repeat_mode = False
+	fanart_notify = True
+	discogs_pat = ""
 
-		self.failed_artists = []
-		self.failed_background_artists = []
+	artist_list_prefer_album_artist = True
 
-		self.artist_list = False
-		self.auto_sort = False
+	mini_mode_mode = 0
+	dc_device_setting = "on"
 
-		self.transcode_inplace = False
+	download_dir1 = ""
+	dd_index = False
 
-		self.bg_showcase_only = False
+	metadata_page_port = 7590
 
-		self.lyrics_enables = []
+	custom_encoder_output = ""
+	column_aa_fallback_artist = False
 
-		self.fatvap = "6b2a9499238ce6416783fc8129b8ac67"
+	meta_persists_stop = False
+	meta_shows_selected = False
+	meta_shows_selected_always = False
 
-		self.fanart_notify = True
-		self.discogs_pat = ""
+	left_align_album_artist_title = False
+	stop_notifications_mini_mode = False
+	scale_want = 1
+	x_scale = True
+	hide_queue = True
+	show_playlist_list = True
+	thin_gallery_borders = False
+	show_current_on_transition = False
 
-		self.artist_list_prefer_album_artist = True
+	chart_rows = 3
+	chart_columns = 3
+	chart_bg: list[int] = field(default_factory=lambda: [7, 7, 7])
+	chart_text = True
+	chart_font = "Monospace 10"
+	chart_tile = False
 
-		self.mini_mode_mode = 0
-		self.dc_device_setting = "on"
+	chart_cascade = False
+	chart_c1 = 5
+	chart_c2 = 6
+	chart_c3 = 10
+	chart_d1 = 2
+	chart_d2 = 2
+	chart_d3 = 2
 
-		self.download_dir1 = ""
-		self.dd_index = False
+	art_in_top_panel = True
+	always_art_header = False
 
-		self.metadata_page_port = 7590
+	# center_bg = True
+	ui_lang: str = "auto"
+	side_panel_layout = 0
+	use_absolute_track_index = False
 
-		self.custom_encoder_output = ""
-		self.column_aa_fallback_artist = False
+	hide_bottom_title = True
+	auto_goto_playing = False
 
-		self.meta_persists_stop = False
-		self.meta_shows_selected = False
-		self.meta_shows_selected_always = False
+	diacritic_search = True
+	increase_gallery_row_spacing = False
+	center_gallery_text = False
 
-		self.left_align_album_artist_title = False
-		self.stop_notifications_mini_mode = False
-		self.scale_want = 1
-		self.x_scale = True
-		self.hide_queue = True
-		self.show_playlist_list = True
-		self.thin_gallery_borders = False
-		self.show_current_on_transition = False
+	tracklist_y_text_offset = 0
+	theme_name = "Turbo"
+	transparent_mode: int = 0
+	left_panel_mode = "playlist"
 
-		self.force_subpixel_text = False
-		if gtk_settings and gtk_settings.get_property("gtk-xft-rgba") == "rgb":
-			self.force_subpixel_text = True
+	folder_tree_codec_colours = False
 
-		self.chart_rows = 3
-		self.chart_columns = 3
-		self.chart_bg = [7, 7, 7]
-		self.chart_text = True
-		self.chart_font = "Monospace 10"
-		self.chart_tile = False
+	network_stream_bitrate = 0  # 0 is off
 
-		self.chart_cascade = False
-		self.chart_c1 = 5
-		self.chart_c2 = 6
-		self.chart_c3 = 10
-		self.chart_d1 = 2
-		self.chart_d2 = 2
-		self.chart_d3 = 2
+	show_side_lyrics_art_panel = True
 
-		self.art_in_top_panel = True
-		self.always_art_header = False
+	gst_use_custom_output = False
 
-		# self.center_bg = True
-		self.ui_lang: str = "auto"
-		self.side_panel_layout = 0
-		self.use_absolute_track_index = False
+	notify_include_album = True
 
-		self.hide_bottom_title = True
-		self.auto_goto_playing = False
+	auto_dl_artist_data = False
 
-		self.diacritic_search = True
-		self.increase_gallery_row_spacing = False
-		self.center_gallery_text = False
+	enable_fanart_artist = False
+	enable_fanart_bg = False
+	enable_fanart_cover = False
 
-		self.tracklist_y_text_offset = 0
-		self.theme_name = "Turbo"
-		self.transparent_mode:     int = 0
-		self.left_panel_mode = "playlist"
+	always_auto_update_playlists = False
 
-		self.folder_tree_codec_colours = False
+	subsonic_server = "http://localhost:4040"
+	subsonic_user = ""
+	subsonic_password = ""
+	subsonic_password_plain = False
 
-		self.network_stream_bitrate = 0  # 0 is off
+	subsonic_playlists = {}
 
-		self.show_side_lyrics_art_panel = True
+	write_ratings = False
+	rating_playtime_stars = False
 
-		self.gst_use_custom_output = False
+	lyrics_subs = {}
 
-		self.notify_include_album = True
+	radio_urls: list = field(default_factory=list)
 
-		self.auto_dl_artist_data = False
+	lyric_metadata_panel_top = False
+	showcase_overlay_texture = False
 
-		self.enable_fanart_artist = False
-		self.enable_fanart_bg = False
-		self.enable_fanart_cover = False
+	sync_target = ""
+	sync_deletes = False
+	sync_playlist: int | None = None
+	download_playlist: int | None = None
 
-		self.always_auto_update_playlists = False
+	sep_genre_multi = False
+	topchart_sorts_played = True
 
-		self.subsonic_server = "http://localhost:4040"
-		self.subsonic_user = ""
-		self.subsonic_password = ""
-		self.subsonic_password_plain = False
+	spot_client = ""
+	spot_secret = ""
+	spot_username = ""
+	spot_password = ""
+	spot_mode = False
+	launch_spotify_web = False
+	launch_spotify_local = False
+	remove_network_tracks = False
+	bypass_transcode = False
+	force_hide_max_button = False
+	zoom_art = False
+	auto_rec = False
+	radio_record_codec = "OPUS"
+	pa_fast_seek = False
+	precache = False
+	# TODO(Martin): cache_list isn't really used anywhere and will always be empty?
+	cache_list: list[str] = field(default_factory=list)
+	cache_limit = 2000  # in mb
+	save_window_position = True
+	spotify_token = ""
+	always_ffmpeg = False
 
-		self.subsonic_playlists = {}
+	use_libre_fm = False
+	back_restarts = False
 
-		self.write_ratings = False
-		self.rating_playtime_stars = False
+	old_playlist_box_position = 0
+	listenbrainz_url = ""
+	maloja_enable = False
+	maloja_url = ""
+	maloja_key = ""
 
-		self.lyrics_subs = {}
+	scrobble_hold = False
 
-		self.radio_urls = []
+	artist_list_sort_mode = "alpha"
 
-		self.lyric_metadata_panel_top = False
-		self.showcase_overlay_texture = False
+	phazor_device_selected = "Default"
+	phazor_devices = ["Default"]
+	bg_flips = set()
+	use_tray = False
+	tray_show_title = False
+	drag_to_unpin = True
+	enable_remote = False
 
-		self.sync_target = ""
-		self.sync_deletes = False
-		self.sync_playlist: int | None = None
-		self.download_playlist: int | None = None
+	artist_list_style = 1
+	discord_enable = False
+	stop_end_queue = False
 
-		self.sep_genre_multi = False
-		self.topchart_sorts_played = True
+	block_suspend = False
+	smart_bypass = True
+	seek_interval = 15
+	shuffle_lock = False
+	album_shuffle_lock_mode = False
+	premium = False
+	radio_thumb_bans: list = field(default_factory=list)
+	show_nag = False
 
-		self.spot_client = ""
-		self.spot_secret = ""
-		self.spot_username = ""
-		self.spot_password = ""
-		self.spot_mode = False
-		self.launch_spotify_web = False
-		self.launch_spotify_local = False
-		self.remove_network_tracks = False
-		self.bypass_transcode = False
-		self.force_hide_max_button = False
-		self.zoom_art = False
-		self.auto_rec = False
-		self.radio_record_codec = "OPUS"
-		self.pa_fast_seek = False
-		self.precache = False
-		# TODO(Martin): cache_list isn't really used anywhere and will always be empty?
-		self.cache_list: list[str] = []
-		self.cache_limit = 2000  # in mb
-		self.save_window_position = True
-		self.spotify_token = ""
-		self.always_ffmpeg = False
+	playlist_exports = {}
+	show_chromecast = False
 
-		self.use_libre_fm = False
-		self.back_restarts = False
+	samplerate = 48000
+	resample = 1
+	volume_power = 2
 
-		self.old_playlist_box_position = 0
-		self.listenbrainz_url = ""
-		self.maloja_enable = False
-		self.maloja_url = ""
-		self.maloja_key = ""
+	tmp_cache = True
 
-		self.scrobble_hold = False
+	sat_url = ""
+	lyrics_font_size = 15
 
-		self.artist_list_sort_mode = "alpha"
+	use_gamepad = True
+	avoid_resampling = False
+	use_scancodes = False
 
-		self.phazor_device_selected = "Default"
-		self.phazor_devices = ["Default"]
-		self.bg_flips = set()
-		self.use_tray = False
-		self.tray_show_title = False
-		self.drag_to_unpin = True
-		self.enable_remote = False
+	artist_list_threshold = 4
+	allow_video_formats = True
+	mini_mode_on_top = True
+	tray_theme = "pink"
 
-		self.artist_list_style = 1
-		self.discord_enable = False
-		self.stop_end_queue = False
+	lastfm_pull_love = False
+	row_title_format = 1
+	row_title_genre = False
+	row_title_separator_type = 1
+	search_on_letter = True
 
-		self.block_suspend = False
-		self.smart_bypass = True
-		self.seek_interval = 15
-		self.shuffle_lock = False
-		self.album_shuffle_lock_mode = False
-		self.premium = False
-		self.power_save = False
-		if macos or phone:
-			self.power_save = True
-		self.left_window_control = macos or left_window_control
-		self.macstyle = macos or detect_macstyle
-		self.radio_thumb_bans = []
-		self.show_nag = False
-
-		self.playlist_exports = {}
-		self.show_chromecast = False
-
-		self.samplerate = 48000
-		self.resample = 1
-		self.volume_power = 2
-
-		self.tmp_cache = True
-
-		self.sat_url = ""
-		self.lyrics_font_size = 15
-
-		self.use_gamepad = True
-		self.avoid_resampling = False
-		self.use_scancodes = False
-
-		self.artist_list_threshold = 4
-		self.allow_video_formats = True
-		self.mini_mode_on_top = True
-		self.tray_theme = "pink"
-
-		self.lastfm_pull_love = False
-		self.row_title_format = 1
-		self.row_title_genre = False
-		self.row_title_separator_type = 1
-		self.search_on_letter = True
-
-		self.gallery_combine_disc = False
-		self.pipewire = False
-		self.tidal_quality = 1
+	gallery_combine_disc = False
+	pipewire = False
+	tidal_quality = 1


### PR DESCRIPTION
Start pushing larger changes from #1388 - converts the Prefs class to a dataclass

This makes it nicer to define by getting rid of the init function and all the `self` references.  
Logic for the couple vars that had it is now handled outside of the class.