### PR TITLE
Add Ruff to CI steps, disabled for now

### DIFF
--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -1,0 +1,40 @@
+name: Build and release
+
+# Temporarily only run outside of master to not have ugly red checkmarks there, needs ruleset changes, #1388 merged and a bunch of code polish to be really useful
+on:
+  push:
+    branches:
+      - '*'
+      - '!master'
+  pull_request:
+    branches:
+      - '*'
+      - '!master'
+
+jobs:
+  ruff:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install Python dependencies and setup venv
+        run: |
+          python -m pip install --upgrade pip
+          python -m venv .venv
+          source .venv/bin/activate
+          pip install ruff
+
+      - name: Run Ruff
+        # We do not want to completely fail all CI if Ruff has complaints
+        continue-on-error: true
+        run: |
+          source .venv/bin/activate
+          ruff check --config pyproject.toml .


### PR DESCRIPTION
Adds a Ruff run to the CI against the ruleset defined in pyproject.toml.

Disabled on `master` for now as this needs #1388 to be any useful, the ruleset needs changes too, but the job otherwise works just fine.  

If this were enabled as-is, we'd make all CI jobs have an ugly red checkmark.