### PR TITLE
Fix download_img() parameter

### DIFF
--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -37499,7 +37499,7 @@ def dismiss_dl():
 	dl_mon.done.update(dl_mon.watching)
 	dl_mon.watching.clear()
 
-def download_img(link: str, target_folder: str, track: TrackClass) -> None:
+def download_img(link: str, target_dir: str, track: TrackClass) -> None:
 	try:
 		response = urllib.request.urlopen(link, context=tls_context)
 		info = response.info()


### PR DESCRIPTION
This worked til now since it ended up relying on an implicit global I suppose.