### PR TITLE
Implement Inno Setup in CI

### DIFF
--- a/.github/release_body.md
+++ b/.github/release_body.md
@@ -21,6 +21,7 @@
 				<td>
 					<!-- MS Logos were removed from Simpleicons so just ship the singular SVG here -->
 					<a href="https://github.com/Taiko2k/Tauon/releases/download/RELEASE_TAG/TauonMusicBox-windows.zip"><img src="https://img.shields.io/badge/Portable-x64-0078d7.svg?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZD0iTTAgMGgxMS4zNzd2MTEuMzcySDBabTEyLjYyMyAwSDI0djExLjM3MkgxMi42MjNaTTAgMTIuNjIzaDExLjM3N1YyNEgwWm0xMi42MjMgMEgyNFYyNEgxMi42MjMiLz48L3N2Zz4="></a><br>
+					<a href="https://github.com/Taiko2k/Tauon/releases/download/RELEASE_TAG/TauonMusicBox-windows-installer.zip"><img src="https://img.shields.io/badge/Installer-x64-0078d7.svg?logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZD0iTTAgMGgxMS4zNzd2MTEuMzcySDBabTEyLjYyMyAwSDI0djExLjM3MkgxMi42MjNaTTAgMTIuNjIzaDExLjM3N1YyNEgwWm0xMi42MjMgMEgyNFYyNEgxMi42MjMiLz48L3N2Zz4="></a><br>
 				</td>
 			</tr>
 			<tr>

--- a/.github/workflows/build_and_release.yaml
+++ b/.github/workflows/build_and_release.yaml
@@ -297,12 +297,35 @@ jobs:
 
           7z a -r "${ARCHIVE_PATH}" "."
 
+#      - name: "[DEBUG] List all files after pyinstaller"
+#        shell: msys2 {0}
+#        run: find .
+
       - name: Upload 7Z artifact
         uses: actions/upload-artifact@v4
         with:
           name: TauonMusicBox-windows
           path: TauonMusicBox.7z
 
+      - name: Replace Tauon version in .ISS
+        run: |
+          sed -i 's|{{ tauon_version }}|8.0.0|g' extra/setup.iss
+
+      - name: Compile .ISS to .EXE Installer
+        uses: Minionguyjpro/Inno-Setup-Action@v1.2.5
+        with:
+          path: extra/setup.iss
+          options: /O+
+
+#      - name: "[DEBUG] List all files after Inno"
+#        shell: msys2 {0}
+#        run: find .
+
+      - name: Upload EXE installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: TauonMusicBox-windows-installer
+          path: extra/Output/tauonsetup-8.0.0.exe
 
   get-info:
     runs-on: ubuntu-24.04

--- a/extra/setup.iss
+++ b/extra/setup.iss
@@ -3,24 +3,24 @@
 ; NOTE: The value of AppId uniquely identifies this application.
 ; Do not use the same AppId value in installers for other applications.
 ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
+
+; Extra { here is indeed necessary!
 AppId={{8793586B-AC0A-47EB-97D6-4060D8D63CB4}
 AppName=Tauon
-AppVersion=7.9.0
+AppVersion={{ tauon_version }}
 
 AppPublisher=Taiko2k
 AppPublisherURL=https://github.com/Taiko2k/TauonMusicBox
 AppSupportURL=https://github.com/Taiko2k/TauonMusicBox
 AppUpdatesURL=https://github.com/Taiko2k/TauonMusicBox
-DefaultDirName={pf}\Tauon Music Box
+DefaultDirName={commonpf}\Tauon Music Box
 DisableProgramGroupPage=yes
-OutputBaseFilename=setup
+OutputBaseFilename=tauonsetup-{{ tauon_version }}
 Compression=lzma
 SolidCompression=yes
-ArchitecturesInstallIn64BitMode=x64
-ArchitecturesAllowed=x64
-SetupIconFile=C:\<???>\TauonMusicBox\_internal\assets\icon.ico
-
-
+ArchitecturesInstallIn64BitMode=x64os
+ArchitecturesAllowed=x64os
+SetupIconFile=D:\a\Tauon\Tauon\dist\TauonMusicBox\_internal\assets\icon.ico
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
@@ -29,14 +29,13 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-Source: "C:\<???>\TauonMusicBox\tauon.exe"; DestDir: "{app}"; Flags: ignoreversion
-Source: "C:\<???>\TauonMusicBox\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "D:\a\Tauon\Tauon\dist\TauonMusicBox\Tauon Music Box.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "D:\a\Tauon\Tauon\dist\TauonMusicBox\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Icons]
-Name: "{commonprograms}\Tauon"; Filename: "{app}\Tauon.exe"
-Name: "{commondesktop}\Tauon"; Filename: "{app}\Tauon.exe"; Tasks: desktopicon
+Name: "{commonprograms}\Tauon"; Filename: "{app}\Tauon Music Box.exe"
+Name: "{commondesktop}\Tauon"; Filename: "{app}\Tauon Music Box.exe"; Tasks: desktopicon
 
 [Run]
-Filename: "{app}\Tauon.exe"; Description: "{cm:LaunchProgram,Tauon}"; Flags: nowait postinstall skipifsilent
-
+Filename: "{app}\Tauon Music Box.exe"; Description: "{cm:LaunchProgram,Tauon}"; Flags: nowait postinstall skipifsilent


### PR DESCRIPTION
https://jrsoftware.org/ishelp/index.php

Fixes #1445

- [ ] Option flag - I left the default -O flag as per the example, is this okay?
- [ ] Dynamic version
- [x] *Warning: Architecture identifier "x64" is deprecated. Substituting "x64os", but note that "x64compatible" is preferred in most cases. See the "Architecture Identifiers" topic in help file for more information.* - https://jrsoftware.org/ishelp/index.php?topic=archidentifiers
- [x] *Warning: Constant "pf" has been renamed. Use "commonpf" instead or consider using its "auto" form.*
- [x] *Warning: Setting the [Setup] section directive "OutputBaseFileName" to "setup" is not recommended: all executables named "setup.exe" are shimmed by Windows application compatibility to load additional DLLs, such as version.dll. These DLLs are loaded unsafely by Windows and can be hijacked. Use a different name, for example "mysetup".*
