### PR TITLE
Fix on shift selection

### DIFF
--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -42909,11 +42909,11 @@ while pctl.running:
 				if keymaps.test("shift-up") and pctl.selected_in_playlist > -1:
 					gui.pl_update += 1
 					if pctl.selected_in_playlist > len(default_playlist) - 1:
-						pctl.selected_in_playlist = 0
+						pctl.selected_in_playlist = len(default_playlist) - 1
 
 					if not shift_selection:
 						shift_selection.append(pctl.selected_in_playlist)
-					if pctl.selected_in_playlist < len(default_playlist) - 1:
+					if pctl.selected_in_playlist > 0:
 						r = pctl.selected_in_playlist
 						pctl.selected_in_playlist -= 1
 						if pctl.selected_in_playlist not in shift_selection:


### PR DESCRIPTION
Changes should fix two scenarios:

- Issue with first track which was on selection, when we wanted to go down, there was one extra selection.
- Issue which has caused by the last track selection in the upward direction, which was exceeding the range of the list, resulting the selection was getting stuck at the end of the list.