### PR TITLE
Ship our own SDL3 binaries in Windows CI releases

### DIFF
--- a/src/tauon/__main__.py
+++ b/src/tauon/__main__.py
@@ -20,11 +20,18 @@ import logging
 import os
 import pickle
 import sys
-from ctypes import c_int, pointer, c_float, byref
+from ctypes import byref, c_float, c_int, pointer
 from pathlib import Path
 
-from gi.repository import GLib
+# We currently only properly package SDL3 on Windows, remove the if check when macOS and Linux is fixed
+if sys.platform == "win32":
+	os.environ["SDL_BINARY_PATH"]              = "." # Set the path to your binaries,               "sdl3/bin" by default.
+	os.environ["SDL_DISABLE_METADATA"]         = "1" # Disable metadata method,                     "0"        by default.
+	os.environ["SDL_CHECK_BINARY_VERSION"]     = "0" # Disable binary version checking,             "1"        by default.
+	os.environ["SDL_IGNORE_MISSING_FUNCTIONS"] = "1" # Disable missing function warnings,           "0"        by default.
+	os.environ["SDL_FIND_BINARIES"]            = "0" # Search for binaries in the system libraries, "1"        by default.
 import sdl3
+from gi.repository import GLib
 
 install_directory: Path = Path(__file__).resolve().parent
 sys.path.append(str(install_directory.parent))

--- a/windows.spec
+++ b/windows.spec
@@ -35,9 +35,9 @@ a = Analysis(
 		(str(Path(msys64_path) / "mingw64" / "bin" / "libvorbis-0.dll"),     "."),
 		(str(Path(msys64_path) / "mingw64" / "bin" / "libvorbisfile-3.dll"), "."),
 		(str(Path(msys64_path) / "mingw64" / "bin" / "libwavpack-1.dll"),    "."),
-		(str(Path(msys64_path) / "mingw64" / "bin" / "SDL3.dll"),            "."),
-		(str(Path(msys64_path) / "mingw64" / "bin" / "SDL3_image.dll"),      "."),
-		(str(Path(msys64_path) / "mingw64" / "bin" / "SDL3_ttf.dll"),      "."),
+		(str(Path(msys64_path) / "mingw64" / "bin" / "SDL3.dll"),            "./sdl3/bin"),
+		(str(Path(msys64_path) / "mingw64" / "bin" / "SDL3_image.dll"),      "./sdl3/bin"),
+		(str(Path(msys64_path) / "mingw64" / "bin" / "SDL3_ttf.dll"),        "./sdl3/bin"),
 	],
 	datas=[
 		(certifi.where(), "certifi"),

--- a/windows.spec
+++ b/windows.spec
@@ -17,27 +17,27 @@ def find_msys64_path() -> Path:
 	raise FileNotFoundError("MSYS2 base path not found in common locations")
 
 python_ver = f"{sys.version_info.major}.{sys.version_info.minor}"
-msys64_path = find_msys64_path()
+msys64_path = Path(find_msys64_path())
 print(f"Found msys64 path: {msys64_path}")
 
 a = Analysis(
 	["src/tauon/__main__.py"],
 	pathex=[],
 	binaries=[
-		(str(Path(msys64_path) / "mingw64" / "bin" / "libFLAC.dll"),         "."),
-		(str(Path(msys64_path) / "mingw64" / "bin" / "libgme.dll"),          "."),
-		(str(Path(msys64_path) / "mingw64" / "bin" / "libmpg123-0.dll"),     "."),
-		(str(Path(msys64_path) / "mingw64" / "bin" / "libogg-0.dll"),        "."),
-		(str(Path(msys64_path) / "mingw64" / "bin" / "libopenmpt-0.dll"),    "."),
-		(str(Path(msys64_path) / "mingw64" / "bin" / "libopus-0.dll"),       "."),
-		(str(Path(msys64_path) / "mingw64" / "bin" / "libopusfile-0.dll"),   "."),
-		(str(Path(msys64_path) / "mingw64" / "bin" / "libsamplerate-0.dll"), "."),
-		(str(Path(msys64_path) / "mingw64" / "bin" / "libvorbis-0.dll"),     "."),
-		(str(Path(msys64_path) / "mingw64" / "bin" / "libvorbisfile-3.dll"), "."),
-		(str(Path(msys64_path) / "mingw64" / "bin" / "libwavpack-1.dll"),    "."),
-		(str(Path(msys64_path) / "mingw64" / "bin" / "SDL3.dll"),            "./sdl3/bin"),
-		(str(Path(msys64_path) / "mingw64" / "bin" / "SDL3_image.dll"),      "./sdl3/bin"),
-		(str(Path(msys64_path) / "mingw64" / "bin" / "SDL3_ttf.dll"),        "./sdl3/bin"),
+		(str(msys64_path / "mingw64" / "bin" / "libFLAC.dll"),         "."),
+		(str(msys64_path / "mingw64" / "bin" / "libgme.dll"),          "."),
+		(str(msys64_path / "mingw64" / "bin" / "libmpg123-0.dll"),     "."),
+		(str(msys64_path / "mingw64" / "bin" / "libogg-0.dll"),        "."),
+		(str(msys64_path / "mingw64" / "bin" / "libopenmpt-0.dll"),    "."),
+		(str(msys64_path / "mingw64" / "bin" / "libopus-0.dll"),       "."),
+		(str(msys64_path / "mingw64" / "bin" / "libopusfile-0.dll"),   "."),
+		(str(msys64_path / "mingw64" / "bin" / "libsamplerate-0.dll"), "."),
+		(str(msys64_path / "mingw64" / "bin" / "libvorbis-0.dll"),     "."),
+		(str(msys64_path / "mingw64" / "bin" / "libvorbisfile-3.dll"), "."),
+		(str(msys64_path / "mingw64" / "bin" / "libwavpack-1.dll"),    "."),
+		(str(msys64_path / "mingw64" / "bin" / "SDL3.dll"),            "."),
+		(str(msys64_path / "mingw64" / "bin" / "SDL3_image.dll"),      "."),
+		(str(msys64_path / "mingw64" / "bin" / "SDL3_ttf.dll"),        "."),
 	],
 	datas=[
 		(certifi.where(), "certifi"),


### PR DESCRIPTION
Currently we ship them in the root of the program as per PySDL2, but in PySDL3 they're expected in ./sdl3/bin by default.

We set the appropriate env vars to ensure PySDL3 does not try to autodownload and override the lib dir to `.` pwd.

Related issue - https://github.com/Taiko2k/Tauon/issues/1437

Windows only, macOS and Linux is TODO.