### PR TITLE
Fix capitalization for Windows checks

### DIFF
--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -12195,8 +12195,8 @@ class Over:
 			self.toggle_square(x, y, toggle_titlebar_line, _("Show playing in titlebar"))
 
 		#y += 25 * gui.scale
-		# if system != 'windows' and (flatpak_mode or snap_mode):
-		#     self.toggle_square(x, y, toggle_force_subpixel, _("Enable RGB text antialiasing"))
+		# if system != "Windows" and (flatpak_mode or snap_mode):
+		# 	self.toggle_square(x, y, toggle_force_subpixel, _("Enable RGB text antialiasing"))
 
 		y += 25 * gui.scale
 		old = prefs.mini_mode_on_top
@@ -24072,7 +24072,7 @@ def load_prefs():
 	prefs.center_gallery_text = cf.sync_add("bool", "gallery-center-text", prefs.center_gallery_text)
 
 	# show-current-on-transition", prefs.show_current_on_transition)
-	if system != "windows":
+	if system != "Windows":
 		cf.br()
 		cf.add_text("[fonts]")
 		cf.add_comment("Changes will require app restart.")
@@ -38069,13 +38069,13 @@ def update_layout_do():
 
 		bottom_bar1.update()
 
-		# if system != 'windows':
-		#     if draw_border:
-		#         gui.panelY = 30 * gui.scale + 3 * gui.scale
-		#         top_panel.ty = 3 * gui.scale
-		#     else:
-		#         gui.panelY = 30 * gui.scale
-		#         top_panel.ty = 0
+		# if system != "Windows":
+		# 	if draw_border:
+		# 		gui.panelY = 30 * gui.scale + 3 * gui.scale
+		# 		top_panel.ty = 3 * gui.scale
+		# 	else:
+		# 		gui.panelY = 30 * gui.scale
+		# 		top_panel.ty = 0
 
 		if gui.set_bar and gui.set_mode:
 			gui.playlist_top = gui.playlist_top_bk + gui.set_height - 6 * gui.scale
@@ -41657,7 +41657,7 @@ lyric_side_top_pulse = EdgePulse2()
 lyric_side_bottom_pulse = EdgePulse2()
 
 # Set SDL window drag areas
-# if system != 'windows':
+# if system != "Windows":
 
 c_hit_callback = sdl3.SDL_HitTest(hit_callback)
 sdl3.SDL_SetWindowHitTest(t_window, c_hit_callback, 0)
@@ -42048,7 +42048,7 @@ while pctl.running:
 			#logging.info(link)
 
 			if pctl.playing_ready() and link.startswith("http"):
-				if system != "windows" and sdl3.SDL_version >= 204:
+				if system != "Windows" and sdl3.SDL_version >= 204:
 					gmp = get_global_mouse()
 					gwp = get_window_position()
 					i_x = gmp[0] - gwp[0]


### PR DESCRIPTION
Looks like two Windows things were executing when they shouldn't be - font settings and drag and drop of text - we set `system` to `Windows`, not `windows`, these checks would never pass.

I'm not sure if the logic *actually* shouldn't be executing, but the checks are wrong.

Mildly relevant to #1318