### PR TITLE
Fix crash when enabling persistent network cache

### DIFF
--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -10672,7 +10672,7 @@ class Over:
 			old = prefs.tmp_cache
 			prefs.tmp_cache = self.toggle_square(x, y, prefs.tmp_cache ^ True, _("Use persistent network cache")) ^ True
 			if old != prefs.tmp_cache and tauon.cachement:
-				tauon.cachement.__init__(tauon)
+				tauon.cachement.__init__(self.tauon)
 
 			y += round(22 * gui.scale)
 			ddt.text((x + round(22 * gui.scale), y), _("Cache size"), colours.box_text, 312)

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -10672,7 +10672,7 @@ class Over:
 			old = prefs.tmp_cache
 			prefs.tmp_cache = self.toggle_square(x, y, prefs.tmp_cache ^ True, _("Use persistent network cache")) ^ True
 			if old != prefs.tmp_cache and tauon.cachement:
-				tauon.cachement.__init__()
+				tauon.cachement.__init__(tauon)
 
 			y += round(22 * gui.scale)
 			ddt.text((x + round(22 * gui.scale), y), _("Cache size"), colours.box_text, 312)


### PR DESCRIPTION
Got this crash on latest git when clicking to enable persistent network cache. 
```
Traceback (most recent call last):
  File "/home/mike/Tauon/src/tauon/__main__.py", line 457, in <module>
    main()
  File "/home/mike/Tauon/src/tauon/__main__.py", line 454, in main
    from tauon.t_modules import t_main
  File "/home/mike/Tauon/src/tauon/t_modules/t_main.py", line 45825, in <module>
    pref_box.render()
  File "/home/mike/Tauon/src/tauon/t_modules/t_main.py", line 13271, in render
    self.tabs[self.tab_active][1](x + side_width, y + header_width, content_width, content_height)
  File "/home/mike/Tauon/src/tauon/t_modules/t_main.py", line 10675, in audio
    tauon.cachement.__init__()
TypeError: Cachement.__init__() missing 1 required positional argument: 'tauon'
```

Passing tauon instance to constructor. 