### PR TITLE
Enable fine grained control over desktop notifications

### DIFF
--- a/extra/com.github.taiko2k.tauonmb.desktop
+++ b/extra/com.github.taiko2k.tauonmb.desktop
@@ -22,6 +22,7 @@ Terminal=false
 Type=Application
 Categories=AudioVideo;Player;Audio;
 Actions=PlayPause;Previous;Next;Stop
+X-GNOME-UsesNotifications=true
 
 [Desktop Action PlayPause]
 Exec=com.github.taiko2k.tauonmb.sh --no-start --play-pause

--- a/extra/tauonmb.desktop
+++ b/extra/tauonmb.desktop
@@ -22,6 +22,7 @@ Terminal=false
 Type=Application
 Categories=AudioVideo;Player;Audio;
 Actions=PlayPause;Previous;Next;Stop
+X-GNOME-UsesNotifications=true
 
 [Desktop Action PlayPause]
 Exec=tauon --no-start --play-pause


### PR DESCRIPTION
Fixes #1047

DEs such as Gnome and KDE allow to configure desktop notifications per-application. To enable that, the following line should be present in the `.desktop` file:

```
X-GNOME-UsesNotifications=true
```

See https://developer.gnome.org/documentation/tutorials/notifications.html#disabling-notifications