### PR TITLE
Fix reading radio playlists

### DIFF
--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -6433,10 +6433,11 @@ class Tauon:
 		stations: list[RadioStation] = []
 		for id in ids:
 			if id in urls:
-				radio = RadioPlaylist(
+				radio = RadioStation(
 					stream_url=titles[id] if id in titles else urls[id],
 					title=os.path.splitext(os.path.basename(path))[0],
-					scroll=0)
+					#scroll=0, # TODO(Martin): This was here wrong as scrolling is meant to be for RadioPlaylist?
+					)
 
 				if ".pls" in radio.stream_url:
 					if not followed:


### PR DESCRIPTION
There's two instances (this PR creates the second one) where I had to comment out `scroll=0` and just wanted to confirm before I remove the two commented out lines entirely that it's correct.

It seems to me that the idea was to set scroll for playlists only, but due to the fact both stations and playlists were dictionaries and not class objects it was mistakenly being set here too when it's not needed.