### PR TITLE
Fix loading modules from system install when using a local directory

### DIFF
--- a/linux.spec
+++ b/linux.spec
@@ -1,8 +1,13 @@
 import sys
 
 import certifi
+from pathlib import Path
 
 python_ver = f"{sys.version_info.major}.{sys.version_info.minor}"
+
+ubuntu_lib_path="/usr/lib/x86_64-linux-gnu"
+arch_lib_path="/usr/lib"
+lib_path = ubuntu_lib_path if Path(ubuntu_lib_path).exists() else arch_lib_path
 
 a = Analysis(
 	["src/tauon/__main__.py"],
@@ -10,11 +15,11 @@ a = Analysis(
 	binaries=[],
 	datas=[
 		(certifi.where(), "certifi"),
-		("/usr/lib/x86_64-linux-gnu/gtk-3.0/modules/libcolorreload-gtk-module.so",        "lib/gtk-3.0/modules"),
-		("/usr/lib/x86_64-linux-gnu/gtk-3.0/modules/libwindow-decorations-gtk-module.so", "lib/gtk-3.0/modules"),
-		("/usr/lib/x86_64-linux-gnu/gtk-3.0/modules/libcanberra-gtk-module.so",           "lib/gtk-3.0/modules"),
-		("/usr/lib/x86_64-linux-gnu/gtk-3.0/modules/libcanberra-gtk3-module.so",          "lib/gtk-3.0/modules"),
-		("/usr/lib/x86_64-linux-gnu/girepository-1.0/Notify-0.7.typelib", "gi_typelibs"),
+		(f"{lib_path}/gtk-3.0/modules/libcolorreload-gtk-module.so",        "lib/gtk-3.0/modules"),
+		(f"{lib_path}/gtk-3.0/modules/libwindow-decorations-gtk-module.so", "lib/gtk-3.0/modules"),
+		(f"{lib_path}/gtk-3.0/modules/libcanberra-gtk-module.so",           "lib/gtk-3.0/modules"),
+		(f"{lib_path}/gtk-3.0/modules/libcanberra-gtk3-module.so",          "lib/gtk-3.0/modules"),
+		(f"{lib_path}/girepository-1.0/Notify-0.7.typelib", "gi_typelibs"),
 		("src/tauon/assets", "assets"),
 		("src/tauon/locale", "locale"),
 		("src/tauon/theme", "theme"),

--- a/src/tauon/__main__.py
+++ b/src/tauon/__main__.py
@@ -23,8 +23,9 @@ import sys
 from ctypes import byref, c_float, c_int, pointer
 from pathlib import Path
 
-install_directory: Path = Path(__file__).resolve().parent
-sys.path.append(str(install_directory.parent))
+install_directory = Path(__file__).resolve().parent
+# Make sure we'll load from the parent directory first
+sys.path.insert(0, str(install_directory.parent))
 pyinstaller_mode = bool(hasattr(sys, "_MEIPASS") or getattr(sys, "frozen", False) or install_directory.name.endswith("_internal"))
 
 from gi.repository import GLib


### PR DESCRIPTION
Fixes #1539

Prevents mix and matching files from multiple Tauon installations.

Related pyinstaller discussion, as I initially went on a much different path before discovering the actual issue - https://github.com/orgs/pyinstaller/discussions/9103