### PR TITLE
Deal with multiple albumartist tags in FLAC and OPUS files

### DIFF
--- a/src/tauon/t_modules/t_extra.py
+++ b/src/tauon/t_modules/t_extra.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
 	from collections.abc import Callable
 
 	from tauon.t_modules.t_main import TrackClass
+	from tauon.t_modules.t_tagscan import TrackFile
 
 @dataclass
 class RadioStation:
@@ -1042,7 +1043,7 @@ def d_date_display2(track: TrackClass) -> str:
 		return str(get_year_from_string(track.date)) + " → " + get_year_from_string(track.misc["rdat"])
 	return str(get_year_from_string(track.date))
 
-def process_odat(nt: TrackClass, odat: str) -> None:
+def process_odat(nt: TrackFile, odat: str) -> None:
 	if odat and odat != nt.date and odat != nt.date[:4] and odat != nt.date[-4:] \
 			and nt.date != odat[:4] and nt.date != odat[-4:]:
 		if not nt.date:

--- a/src/tauon/t_modules/t_tagscan.py
+++ b/src/tauon/t_modules/t_tagscan.py
@@ -166,6 +166,7 @@ class Flac:
 		block_position += 4
 		fields = int.from_bytes(buffer, byteorder="little")
 		# logging.info(fields)
+		album_artists: list[str] = []
 		artists: list[str] = []
 		genres: list[str] = []
 		odat = ""
@@ -219,7 +220,8 @@ class Flac:
 					elif a == "encoder":
 						self.encoder = b.decode("utf-8")
 					elif a in ("albumartist", "album artist"):
-						self.album_artist = b.decode("utf-8")
+						#self.album_artist = b.decode("utf-8")
+						album_artists.append(b.decode("utf-8"))
 					elif a == "artist":
 						#self.artist = b.decode("utf-8")
 						artists.append(b.decode())
@@ -254,6 +256,11 @@ class Flac:
 
 		f.seek(block_position * -1, 1)
 
+		if album_artists:
+			#self.album_artist = "; ".join(album_artists)
+			self.album_artist = album_artists[0]
+			if len(album_artists) > 1:
+				self.misc["album_artists"] = album_artists
 		if artists:
 			self.artist = "; ".join(artists)
 			if len(artists) > 1:
@@ -475,6 +482,7 @@ class Opus:
 
 		number = int.from_bytes(s, byteorder="little")  # Number of comments
 
+		album_artists: list[str] = []
 		artists: list[str] = []
 		genres: list[str] = []
 		odat = ""
@@ -530,14 +538,15 @@ class Opus:
 					elif a == "encoder":
 						self.encoder = b.decode("utf-8")
 					elif a in ("albumartist", "album artist"):
-						self.album_artist = b.decode("utf-8")
+						#self.album_artist = b.decode("utf-8")
+						album_artists.append(b.decode("utf-8"))
 					elif a == "artist":
 						#self.artist = b.decode("utf-8")
 						artists.append(b.decode())
 					elif a == "metadata_block_picture":
 
 						logging.info("Tag Scanner: Found picture in OGG/OPUS file.")
-						logging.info("      In file: " + self.filepath)
+						logging.info(f"      In file: {self.filepath}")
 						self.has_picture = True
 						self.picture = b
 						# logging.info(b)
@@ -572,6 +581,11 @@ class Opus:
 
 		v.close()
 
+		if album_artists:
+			#self.album_artist = "; ".join(album_artists)
+			self.album_artist = album_artists[0]
+			if len(album_artists) > 1:
+				self.misc["album_artists"] = album_artists
 		if artists:
 			self.artist = "; ".join(artists)
 			if len(artists) > 1:


### PR DESCRIPTION
Fixes #1578

Looks like `albumartists` can be defined multiple times too, so account for it instead of throwing everything but the last definition.

It's not ideal, as we save the first album artist only, but current behavior only uses the last one, whereas the first one is seemingly always the actual main album artist, later ones being secondary.

Second commit simplifies the module a bit by means of introducing a base class.