### PR TITLE
Fix launching Picard on Windows by using the new 64-bit path

### DIFF
--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -36574,7 +36574,7 @@ def load_prefs(bag: Bag) -> None:
 		prefs.tag_editor_name = cf.sync_add("string", "tag-editor-name", "Picard", "Name to display in UI.")
 		prefs.tag_editor_target = cf.sync_add(
 			"string", "tag-editor-target",
-			"C:\\Program Files (x86)\\MusicBrainz Picard\\picard.exe",
+			"C:\\Program Files\\MusicBrainz Picard\\picard.exe",
 			"The path of the exe to run.")
 	else:
 		prefs.tag_editor_name = cf.sync_add("string", "tag-editor-name", "Picard", "Name to display in UI.")


### PR DESCRIPTION
Fixes #1587, Picard now ships as a 64-bit app so it's no longer in the 32-bit path.

Out of date Picard installations will no longer work after this, but there should be no blockers for people to update.