### PR TITLE
Ffmpeg and streaming changes

### DIFF
--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -2161,7 +2161,7 @@ class PlayerCtl:
 		if self.prefs.art_bg or (self.gui.mode == 3 and self.prefs.mini_mode_mode == 5):
 			self.tauon.thread_manager.ready("style")
 
-	def get_url(self, track_object: TrackClass) -> tuple[str | None, dict | None] | None:
+	def get_url(self, track_object: TrackClass) -> tuple[list[str], str | None, dict | None] | None:
 		if track_object.file_ext == "TIDAL":
 			return self.tauon.tidal.resolve_stream(track_object), None
 		if track_object.file_ext == "PLEX":
@@ -5404,6 +5404,7 @@ class Tauon:
 		self.platform_system              = bag.platform_system
 		self.primary_stations             = bag.primary_stations
 		self.wayland                      = bag.wayland
+		self.msys                         = bag.msys
 		self.dirs                         = bag.dirs
 		self.colours                      = bag.colours
 		self.download_directories         = bag.download_directories
@@ -5478,7 +5479,6 @@ class Tauon:
 		self.quick_import_done: list[str] = []
 		self.move_jobs: list[tuple[str, str, bool, str, LoadClass]] = []
 		self.move_in_progress:       bool = False
-		self.msys                         = bag.msys
 		self.worker2_lock                 = threading.Lock()
 		self.dummy_event:          sdl3.SDL_Event = sdl3.SDL_Event()
 		self.temp_dest                            = sdl3.SDL_FRect(0, 0)
@@ -5739,7 +5739,6 @@ class Tauon:
 		self.chrome: Chrome | None = None
 		self.chrome_menu: Menu | None = None
 
-
 		self.tidal             = Tidal(self)
 		self.plex              = PlexService(self)
 		self.jellyfin          = Jellyfin(self)
@@ -5747,6 +5746,9 @@ class Tauon:
 		self.tau               = TauService(self)
 		self.album_star_store  = AlbumStarStore(self)
 		self.subsonic          = self.album_star_store.subsonic
+
+		self.ffmpeg_path:     Path | None = self.get_ffmpeg()
+		self.ffprobe_path:    Path | None = self.get_ffprobe()
 
 	def coll(self, r: list[int]) -> bool:
 		return r[0] < self.inp.mouse_position[0] <= r[0] + r[2] and r[1] <= self.inp.mouse_position[1] <= r[1] + r[3]
@@ -5758,42 +5760,42 @@ class Tauon:
 			startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
 		try:
 			result = subprocess.run(
-				[self.get_ffprobe(), "-v", "error", "-show_entries", "format=duration", "-of",
+				[str(self.ffprobe_path), "-v", "error", "-show_entries", "format=duration", "-of",
 				"default=noprint_wrappers=1:nokey=1", nt.fullpath], stdout=subprocess.PIPE, startupinfo=startupinfo, check=True)
 			nt.length = float(result.stdout.decode())
 		except Exception:
 			logging.exception("FFPROBE couldn't supply a duration")
 		try:
 			result = subprocess.run(
-				[self.get_ffprobe(), "-v", "error", "-show_entries", "format_tags=title", "-of",
+				[str(self.ffprobe_path), "-v", "error", "-show_entries", "format_tags=title", "-of",
 				"default=noprint_wrappers=1:nokey=1", nt.fullpath], stdout=subprocess.PIPE, startupinfo=startupinfo, check=True)
 			nt.title = str(result.stdout.decode())
 		except Exception:
 			logging.exception("FFPROBE couldn't supply a title")
 		try:
 			result = subprocess.run(
-				[self.get_ffprobe(), "-v", "error", "-show_entries", "format_tags=artist", "-of",
+				[str(self.ffprobe_path), "-v", "error", "-show_entries", "format_tags=artist", "-of",
 				"default=noprint_wrappers=1:nokey=1", nt.fullpath], stdout=subprocess.PIPE, startupinfo=startupinfo, check=True)
 			nt.artist = str(result.stdout.decode())
 		except Exception:
 			logging.exception("FFPROBE couldn't supply a artist")
 		try:
 			result = subprocess.run(
-				[self.get_ffprobe(), "-v", "error", "-show_entries", "format_tags=album", "-of",
+				[str(self.ffprobe_path), "-v", "error", "-show_entries", "format_tags=album", "-of",
 				"default=noprint_wrappers=1:nokey=1", nt.fullpath], stdout=subprocess.PIPE, startupinfo=startupinfo, check=True)
 			nt.album = str(result.stdout.decode())
 		except Exception:
 			logging.exception("FFPROBE couldn't supply a album")
 		try:
 			result = subprocess.run(
-				[self.get_ffprobe(), "-v", "error", "-show_entries", "format_tags=date", "-of",
+				[str(self.ffprobe_path), "-v", "error", "-show_entries", "format_tags=date", "-of",
 				"default=noprint_wrappers=1:nokey=1", nt.fullpath], stdout=subprocess.PIPE, startupinfo=startupinfo, check=True)
 			nt.date = str(result.stdout.decode())
 		except Exception:
 			logging.exception("FFPROBE couldn't supply a date")
 		try:
 			result = subprocess.run(
-				[self.get_ffprobe(), "-v", "error", "-show_entries", "format_tags=track", "-of",
+				[str(self.ffprobe_path), "-v", "error", "-show_entries", "format_tags=track", "-of",
 				"default=noprint_wrappers=1:nokey=1", nt.fullpath], stdout=subprocess.PIPE, startupinfo=startupinfo, check=True)
 			nt.track_number = str(result.stdout.decode())
 		except Exception:
@@ -14228,6 +14230,8 @@ class Tauon:
 				file.write(exe.read())
 
 			exe.close()
+			self.ffmpeg_path = self.get_ffmpeg()
+			self.ffprobe_path = self.get_ffprobe()
 			self.show_message(_("FFMPEG fetch complete"), mode="done")
 
 		shooter(go)
@@ -14392,7 +14396,7 @@ class Tauon:
 
 		target_out = str(output / f"output{track}.{codec})")
 
-		command = self.get_ffmpeg() + " "
+		command = f"{self.ffmpeg_path} "
 
 		if not t.is_cue:
 			command += '-i "'
@@ -15635,7 +15639,7 @@ class Tauon:
 							if self.system == "Windows" or self.msys:
 								startupinfo = subprocess.STARTUPINFO()
 								startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-							result = subprocess.run([self.get_ffprobe(), "-v", "error", "-show_entries", "format=duration", "-of", "default=noprint_wrappers=1:nokey=1", nt.fullpath], stdout=subprocess.PIPE, startupinfo=startupinfo, check=True)
+							result = subprocess.run([str(self.ffprobe_path), "-v", "error", "-show_entries", "format=duration", "-of", "default=noprint_wrappers=1:nokey=1", nt.fullpath], stdout=subprocess.PIPE, startupinfo=startupinfo, check=True)
 							nt.length = float(result.stdout.decode())
 						except Exception:
 							logging.exception("FFPROBE couldn't supply a duration")
@@ -17811,7 +17815,9 @@ class Tauon:
 		return str(self.cache_directory / "icon-export" / f"{name}.svg")
 
 	def test_ffmpeg(self) -> bool:
-		if self.get_ffmpeg():
+		test_result = self.get_ffmpeg()
+		self.ffmpeg_path = test_result
+		if test_result:
 			return True
 		if self.msys:
 			self.show_message(_("This feature requires FFMPEG. Shall I can download that for you? (80MB)"), mode="confirm")
@@ -17821,34 +17827,34 @@ class Tauon:
 			self.show_message(_("FFMPEG could not be found"))
 		return False
 
-	def get_ffmpeg(self) -> str | None:
+	def get_ffmpeg(self) -> Path | None:
 		path = self.user_directory / "ffmpeg.exe"
 		if self.msys and path.is_file():
-			return str(path)
+			return path
 
 		# macOS
 		path = self.install_directory / "ffmpeg"
 		if path.is_file():
-			return str(path)
+			return path
 
 		path = shutil.which("ffmpeg")
 		if path:
-			return path
+			return Path(path)
 		return None
 
-	def get_ffprobe(self) -> str | None:
+	def get_ffprobe(self) -> Path | None:
 		path = self.user_directory / "ffprobe.exe"
 		if self.msys and path.is_file():
-			return str(path)
+			return path
 
 		# macOS
 		path = self.install_directory / "ffprobe"
 		if path.is_file():
-			return str(path)
+			return path
 
 		path = shutil.which("ffprobe")
 		if path:
-			return path
+			return Path(path)
 		return None
 
 	def bg_save(self) -> None:

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -14193,12 +14193,12 @@ class Tauon:
 
 	def download_ffmpeg(self, x) -> None:
 		def go() -> None:
-			url = "https://github.com/GyanD/codexffmpeg/releases/download/5.0.1/ffmpeg-5.0.1-essentials_build.zip"
-			sha = "9e00da9100ae1bba22b1385705837392e8abcdfd2efc5768d447890d101451b5"
+			url = "https://github.com/GyanD/codexffmpeg/releases/download/7.1.1/ffmpeg-7.1.1-essentials_build.zip"
+			sha = "04861d3339c5ebe38b56c19a15cf2c0cc97f5de4fa8910e4d47e5e6404e4a2d4"
 			self.show_message(_("Starting download..."))
 			try:
 				f = io.BytesIO()
-				r = requests.get(url, stream=True, timeout=1800) # ffmpeg is 77MB, give it half an hour in case someone is willing to suffer it on a slow connection
+				r = requests.get(url, stream=True, timeout=1800) # ffmpeg is 88MB, give it half an hour in case someone is willing to suffer it on a slow connection
 
 				dl = 0
 				for data in r.iter_content(chunk_size=4096):
@@ -14208,7 +14208,7 @@ class Tauon:
 					if mb > 90:
 						break
 					if mb % 5 == 0:
-						self.show_message(_("Downloading... {N}/80MB").format(N=mb))
+						self.show_message(_("Downloading... {N}/88MB").format(N=mb))
 
 			except Exception as e:
 				logging.exception("Download failed")
@@ -14221,11 +14221,11 @@ class Tauon:
 			self.show_message(_("Download completed.. extracting"))
 			f.seek(0)
 			z = zipfile.ZipFile(f, mode="r")
-			exe = z.open("ffmpeg-5.0.1-essentials_build/bin/ffmpeg.exe")
+			exe = z.open("ffmpeg-7.1.1-essentials_build/bin/ffmpeg.exe")
 			with (self.user_directory / "ffmpeg.exe").open("wb") as file:
 				file.write(exe.read())
 
-			exe = z.open("ffmpeg-5.0.1-essentials_build/bin/ffprobe.exe")
+			exe = z.open("ffmpeg-7.1.1-essentials_build/bin/ffprobe.exe")
 			with (self.user_directory / "ffprobe.exe").open("wb") as file:
 				file.write(exe.read())
 
@@ -17820,7 +17820,7 @@ class Tauon:
 		if test_result:
 			return True
 		if self.msys:
-			self.show_message(_("This feature requires FFMPEG. Shall I can download that for you? (80MB)"), mode="confirm")
+			self.show_message(_("This feature requires FFMPEG. Shall I can download that for you? (88MB)"), mode="confirm")
 			self.gui.message_box_confirm_callback = self.download_ffmpeg
 			self.gui.message_box_confirm_reference = (None,)
 		else:

--- a/src/tauon/t_modules/t_phazor.py
+++ b/src/tauon/t_modules/t_phazor.py
@@ -172,7 +172,7 @@ class FFRun:
 
 	def start(self, uri: bytes, start_ms: int, samplerate: int) -> int:
 		self.close()
-		path = self.tauon.get_ffmpeg()
+		path = self.tauon.ffmpeg_path
 		if not path:
 			self.tauon.test_ffmpeg()
 			return 1
@@ -379,7 +379,7 @@ class Cachement:
 				logging.info("Multi part DL")
 				logging.info(path)
 				ffmpeg_command = [
-					self.tauon.get_ffmpeg(),
+					self.tauon.ffmpeg_path,
 					"-i", "-",      # Input from stdin (pipe the data)
 					"-f", "flac",   # Specify FLAC as the output format explicitly
 					"-c:a", "copy", # Copy FLAC data without re-encoding

--- a/src/tauon/t_modules/t_stream.py
+++ b/src/tauon/t_modules/t_stream.py
@@ -148,6 +148,10 @@ class StreamEnc:
 		return True
 
 	def pump(self) -> None:
+		if not self.tauon.ffmpeg_path:
+			logging.error("Cannot decode as ffmpeg is missing!")
+			return
+
 		aud = self.tauon.aud
 		if self.tauon.prefs.backend != 4 or not aud:
 			logging.error("Radio error: Phazor not loaded")
@@ -156,7 +160,7 @@ class StreamEnc:
 
 		rate = str(self.tauon.prefs.samplerate)
 		cmd = [
-			self.tauon.get_ffmpeg(), "-loglevel", "quiet", "-i", "pipe:0",
+			self.tauon.ffmpeg_path, "-loglevel", "quiet", "-i", "pipe:0",
 			"-acodec", "pcm_s16le", "-f", "s16le", "-ac", "2", "-ar", rate, "-"]
 
 		startupinfo = None
@@ -218,7 +222,6 @@ class StreamEnc:
 
 			time.sleep(0.01)
 
-
 		decoder.terminate()
 		time.sleep(0.1)
 		try:
@@ -228,8 +231,11 @@ class StreamEnc:
 
 		self.pump_running = False
 
-
 	def encode(self) -> None:
+		if not self.tauon.ffmpeg_path:
+			logging.error("Cannot encode as ffmpeg is missing!")
+			return
+
 		self.encode_running = True
 
 		try:
@@ -256,7 +262,7 @@ class StreamEnc:
 			if target_file.is_file():
 				target_file.unlink()
 
-			cmd = [self.tauon.get_ffmpeg(), "-loglevel", "quiet", "-i", "pipe:0", "-acodec", "pcm_s16le", "-f", "s16le", "-ac", "2", "-ar", rate, "-"]
+			cmd = [self.tauon.ffmpeg_path, "-loglevel", "quiet", "-i", "pipe:0", "-acodec", "pcm_s16le", "-f", "s16le", "-ac", "2", "-ar", rate, "-"]
 
 			decoder = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
 			if sys.platform != "win32":

--- a/src/tauon/t_modules/t_stream.py
+++ b/src/tauon/t_modules/t_stream.py
@@ -66,7 +66,7 @@ class StreamEnc:
 
 		self.chunks = {}
 		self.c = 0
-		self.url = None
+		self.url = ""
 
 	def stop(self) -> None:
 		if self.tauon.radiobox.websocket:
@@ -230,11 +230,9 @@ class StreamEnc:
 
 
 	def encode(self) -> None:
-
 		self.encode_running = True
 
 		try:
-
 			while self.c < 20:
 				if self.abort:
 					self.encode_running = False
@@ -254,9 +252,9 @@ class StreamEnc:
 				ext = ".flac"
 				rate = "44100"
 
-			target_file = str(self.tauon.cache_directory / "stream" / ext)
-			if os.path.isfile(target_file):
-				os.remove(target_file)
+			target_file = self.tauon.cache_directory / "stream" / ext
+			if target_file.is_file():
+				target_file.unlink()
 
 			cmd = [self.tauon.get_ffmpeg(), "-loglevel", "quiet", "-i", "pipe:0", "-acodec", "pcm_s16le", "-f", "s16le", "-ac", "2", "-ar", rate, "-"]
 
@@ -269,7 +267,7 @@ class StreamEnc:
 			old_tags = self.tauon.pctl.found_tags
 
 			##cmd = ["opusenc", "--raw", "--raw-rate", "48000", "-", target_file]
-			cmd = ["ffmpeg", "-loglevel", "quiet", "-f", "s16le", "-ar", rate, "-ac", "2", "-i", "pipe:0", target_file]
+			cmd = ["ffmpeg", "-loglevel", "quiet", "-f", "s16le", "-ar", rate, "-ac", "2", "-i", "pipe:0", str(target_file)]
 			encoder = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
 
 			def save_track():
@@ -336,7 +334,6 @@ class StreamEnc:
 				self.tauon.gui.update += 1
 
 			while True:
-
 				if self.abort:
 					decoder.terminate()
 					encoder.terminate()
@@ -350,20 +347,20 @@ class StreamEnc:
 					except Exception:
 						logging.exception("Failed to kill encoder")
 
-					if os.path.exists(target_file):
-						if os.path.getsize(target_file) > 256000:
+					if target_file.exists():
+						if target_file.stat().st_size > 256000:
 							logging.info("Save file")
 							save_track()
 						else:
 							logging.info("Discard small file")
-							os.remove(target_file)
+							target_file.unlink()
 
 					self.encode_running = False
 					self.tauon.pctl.tag_history.clear()
 					return
 
 				if old_metadata != self.tauon.radiobox.song_key:
-					if (self.c < 400 and not old_metadata) or not os.path.exists(target_file) or os.path.getsize(target_file) < 100000:
+					if (self.c < 400 and not old_metadata) or not target_file.exists() or target_file.stat().st_size < 100000:
 						old_metadata = self.tauon.radiobox.song_key
 					else:
 						logging.info("Split and save file")
@@ -376,12 +373,12 @@ class StreamEnc:
 							encoder.kill()
 						except Exception:
 							logging.exception("Failed to kill encoder")
-						if os.path.exists(target_file):
-							if os.path.getsize(target_file) > 256000:
+						if target_file.exists():
+							if target_file.stat().st_size > 256000:
 								save_track()
 							else:
 								logging.info("Discard small file")
-								os.remove(target_file)
+								target_file.unlink()
 						encoder = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
 
 				raw_audio = decoder.stdout.read(1000000)

--- a/src/tauon/t_modules/t_webserve.py
+++ b/src/tauon/t_modules/t_webserve.py
@@ -787,13 +787,12 @@ def authserve(tauon: Tauon) -> None:
 class VorbisMonitor:
 
 	def __init__(self) -> None:
-
-		self.tauon = None
+		self.tauon: Tauon | None = None
 		self.reset()
 		self.enable = True
 		self.synced = False
 		self.buffer = io.BytesIO()
-		self.tries = 0
+		self.tries: int = 0
 
 	def reset(self, tries: int = 0) -> None:
 		self.enable = True
@@ -802,7 +801,6 @@ class VorbisMonitor:
 		self.tries = tries
 
 	def input(self, data: bytes) -> None:
-
 		if not self.enable:
 			return
 


### PR DESCRIPTION
Bump downloaded Windows ffmpeg to 7.1.1 (from 5.0.1).

Stop trying to find ffmpeg/ffprobe binaries each time they're needed, cache them instead.

Start checking if ffmpeg/ffprobe was actually found before attempting to use the result - this might have been logically impossible even in the current code, but the functions themselves had no checks and it made Pyright angry.

Some small typing changes.