### PR TITLE
Subsonic fixes

### DIFF
--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -18103,8 +18103,14 @@ class SubsonicService:
 
 		return d
 
-	def get_cover(self, track_object: TrackClass):
+	def get_cover(self, track_object: TrackClass) -> BytesIO:
 		response = self.r("getCoverArt", p={"id": track_object.art_url_key}, binary=True)
+		try:
+			response.decode('utf-8')
+			raise ValueError(f"Expected binary data with an image but got a valid string: {response}")
+		except UnicodeDecodeError:
+			pass
+
 		return io.BytesIO(response)
 
 	def resolve_stream(self, key):

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -18217,6 +18217,7 @@ class SubsonicService:
 			self.gui.update = 2
 
 			for item in items:
+				#logging.debug(f"song: {item}")
 				if "isDir" in item and item["isDir"]:
 					if "userRating" in item and "artist" in item:
 						rating = item["userRating"]
@@ -18254,7 +18255,7 @@ class SubsonicService:
 					nt.fullpath = song["path"]
 					nt.parent_folder_path = os.path.dirname(song["path"])
 				if "coverArt" in song:
-					nt.art_url_key = song["id"]
+					nt.art_url_key = song["coverArt"]
 				nt.url_key = song["id"]
 				nt.misc["subsonic-folder-id"] = folder_id
 				nt.is_network = True

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -18139,9 +18139,18 @@ class SubsonicService:
 			self.scanning = False
 			return []
 
+		# {'openSubsonic': True, 'serverVersion': '8', 'status': 'failed', 'type': 'lms', 'version': '1.16.0', 'error': {'code': 41, 'message': 'Token authentication not supported for LDAP users.'}}
 		if "indexes" not in a["subsonic-response"]:
+			self.scanning = False
+			if "error" in a["subsonic-response"]:
+				logging.debug(a["subsonic-response"])
+				self.show_message(_("Error connecting to Airsonic server"), f'{a["subsonic-response"]["error"]["code"]}: {a["subsonic-response"]["error"]["message"]}', mode="error")
+				return None
 			logging.critical("Failed to find expected key 'indexes', report a bug with the log below!")
 			logging.critical(a["subsonic-response"])
+			self.show_message(_("Error connecting to Airsonic server"), "See console log for more details", mode="error")
+			return None
+
 		b = a["subsonic-response"]["indexes"]["index"]
 
 		folders: list[tuple[str, str]] = []


### PR DESCRIPTION
Fixes #1112

Fixes #1225

Fix crashing on failed login with some Subsonic implementations and actually show the error message to the user

Fix failed login with some Subsonic implementations due to them sending raw control characters in JSON replies

Raise an exception if a Subsonic cover is a failed response and not a raw image - reported in #1112 - combination of bad lms implementation of error messages and us sending over `id` instead of `coverArt` values

Fix sending `id` instead of `coverArt`, breaking cover arts on some implementations.

My only worry here is if Airsonic still works with cover art as I have no instance to test with, LMS(now fixed) and Navidrome(still works) work fine. It presumably fixes Nextcloud Music too.