### PR TITLE
Use new StarRecord class for StarStore objects

### DIFF
--- a/src/tauon/t_modules/t_extra.py
+++ b/src/tauon/t_modules/t_extra.py
@@ -75,6 +75,20 @@ class RadioPlaylist:
 	stations: list[RadioStation] = field(default_factory=list[RadioStation])
 
 @dataclass
+class StarRecord:
+	"""Playtime in seconds, 0 to 10 rating, loved/hated status & timestamp
+
+	Hate status is currently not implemented. Integrations such as ListenBrainz use it.
+	"""
+
+	playtime:        float = 0
+	rating:            int = 0
+	loved:            bool = False
+	loved_timestamp: float = 0
+	hated:            bool = False
+	hated_timestamp: float = 0
+
+@dataclass
 class TauonQueueItem:
 	"""TauonQueueItem is [trackid, position, playlist_id, type, album_stage, uid_gen(), auto_stop]
 


### PR DESCRIPTION
Refactor StarStore to use class object instead of a list.

Removes `flags` parameter as it was only used for loving a track, now there's a boolean.

Removes an unused `album` variable.

Fixes breaking *really old* migrations, as star_store wasn't being loaded before migration was being processed.

Fixes a bug where the list had an incorrect amount of values, breaking loving a track:
 
```python
2025-05-18 01:57:27 [CRITICAL] [  t_main  ] [1069.17647152688, '', 0] (t_main.py:15846)
Exception in thread Thread-16 (love):
Traceback (most recent call last):
  File "/usr/lib/python3.13/threading.py", line 1041, in _bootstrap_inner
    self.run()
    ~~~~~~~~^^
  File "/usr/lib/python3.13/threading.py", line 992, in run
    self._target(*self._args, **self._kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/tauon/t_modules/t_main.py", line 15846, in love
    star[3] = time.time()
    ~~~~^^^
IndexError: list assignment index out of range
```