### PR TITLE
Fix a crash stemming from reload_albums() returning None

### DIFF
--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -15002,10 +15002,10 @@ class Tauon:
 
 		return h
 
-	def reload_albums(self, quiet: bool = False, return_playlist: int = -1, custom_list: list[int] | None = None) -> list[int] | None:
+	def reload_albums(self, quiet: bool = False, return_playlist: int = -1, custom_list: list[int] | None = None) -> list[int]:
 		if self.cm_clean_db:
 			# Doing reload while things are being removed may cause crash
-			return None
+			return []
 
 		dex = []
 		current_folder = ""
@@ -15065,7 +15065,7 @@ class Tauon:
 		# Generate POWER BAR
 		self.gui.power_bar = self.gen_power2()
 		self.gui.pt = 0
-		return None
+		return []
 
 	def reload_backend(self) -> None:
 		self.gui.backend_reloading = True


### PR DESCRIPTION
Return empty array instead

Should fix this bug:

```python
Traceback (most recent call last):
  File "/usr/bin/tauonmb", line 8, in <module>
    sys.exit(main())
             ~~~~^^
  File "/usr/lib/python3.13/site-packages/tauon/__main__.py", line 456, in main
    from tauon.t_modules import t_main
  File "/usr/lib/python3.13/site-packages/tauon/t_modules/t_main.py", line 44855, in <module>
    tauon.bottom_bar1.render()
    ~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/site-packages/tauon/t_modules/t_main.py", line 27499, in render
    pctl.show_current()
    ~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/site-packages/tauon/t_modules/t_main.py", line 2375, in show_current
    ap = self.tauon.get_album_info(i)[1][0]
         ~~~~~~~~~~~~~~~~~~~~~~~~~^^^
  File "/usr/lib/python3.13/site-packages/tauon/t_modules/t_main.py", line 17766, in get_album_info
    for i, p in enumerate(reversed(dex)):
                          ~~~~~~~~^^^^^
TypeError: 'NoneType' object is not reversible
```