### PR TITLE
CI: Fix Windows runner

### DIFF
--- a/.github/workflows/build_and_release.yaml
+++ b/.github/workflows/build_and_release.yaml
@@ -507,6 +507,12 @@ jobs:
         run: |
           sed -i 's|{{ tauon_version }}|8.1.0|g' extra/setup.iss
 
+      - name: Get current drive letter nad replace what's in .ISS
+        shell: pwsh
+        run: |
+          $Drive = (Get-Item -Path "${{ github.workspace }}").PSDrive.Name + ":\"
+          (Get-Content extra/setup.iss) -replace "C:\\", $Drive | Set-Content extra/setup.iss
+
       - name: Compile .ISS to .EXE Installer
         uses: Minionguyjpro/Inno-Setup-Action@v1.2.6
         with:

--- a/.github/workflows/build_and_release.yaml
+++ b/.github/workflows/build_and_release.yaml
@@ -508,7 +508,7 @@ jobs:
           sed -i 's|{{ tauon_version }}|8.1.0|g' extra/setup.iss
 
       - name: Compile .ISS to .EXE Installer
-        uses: Minionguyjpro/Inno-Setup-Action@v1.2.5
+        uses: Minionguyjpro/Inno-Setup-Action@v1.2.6
         with:
           path: extra/setup.iss
           options: /O+


### PR DESCRIPTION
Bump Inno-Setup-Action to 1.2.6

Use whatever drive letter for .ISS that the runner is using, seems to fluctuate at random between C:\ and D:\