### PR TITLE
Iron out duplicate track filepaths

### DIFF
--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -1651,7 +1651,7 @@ class PlayerCtl:
 		self.loading_in_progress: bool = False
 		self.taskbar_progress:    bool = True
 		self.album_dex                 = self.tauon.album_dex
-		self.deep_duplicates           = False
+		self.deep_duplicates:     bool = False
 
 		self.cargo: list[int]          = []
 		# Database

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -39162,7 +39162,7 @@ def worker1(tauon: Tauon) -> None:
 
 	def deep_remove_duplicates() -> int:
 		paths_ids: dict[str,int] = {}
-		dupes = []
+		dupes: list[int] = []
 		for track in pctl.master_library:
 			if not pctl.master_library[track].fullpath:
 				continue


### PR DESCRIPTION
Per #1633, it is possible to accidentally import the same track and file multiple times if it is done via a playlist file that uses relative paths that include backtracking (`../`). Once #1693 is merged this will not be possible (unless I messed something up which I honestly doubt). However, this doesn't help people who *already have* duplicate paths imported. 

This pull adds an "Iron out duplicate track paths" option under the Database menu. When clicked, it will:
- Run through every track in the master library and determine its absolute path regardless of relative fuckery going on
- Compare this path to its history. If the path already exists in the history (i.e. there's another track with the exact same filepath), it will
- Replace every instance of the duplicate track ID with the known good track ID in every playlist
- Then, if the playlist DID NOT ALREADY have ID duplicates, run `remove_duplicates` (thus dealing with generator playlists and such, where the track would appear twice under two different IDs)
- Delete the duplicate track entry from the master library