### PR TITLE
Synced mode: click to seek to lyric, scrolling while playing

### DIFF
--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -19737,7 +19737,7 @@ class TimedLyricsRen:
 				sum( self.line_heights[i: max(0,line_active) ] ) + \
 				sum( self.line_heights[ max(line_active,0) :i] )
 
-			if 0 < possible_y < self.window_size[1]:
+			if 0 < possible_y - self.line_heights[i] and possible_y < self.window_size[1]:
 				colour = self.colours.lyrics
 
 				#colour = self.colours.grey(70)

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -19587,14 +19587,11 @@ class TimedLyricsRen:
 
 		self.scroll_position: int = 0
 		self.scroll        = tauon.smooth_scroll
-<<<<<<< HEAD
-=======
 
 		self.recenter_timeout = Timer()
 		self.temp_line: int = -1
 		self.temp_scale: float | None = None
 		self.temp_w: int | None = None
->>>>>>> e055b924 (Improved synced lyrics display)
 
 	def generate(self, track: TrackClass) -> bool | None:
 		if self.index == track.index:
@@ -19663,21 +19660,15 @@ class TimedLyricsRen:
 
 		if not self.ready:
 			return False
-<<<<<<< HEAD
-		if self.inp.mouse_wheel and (self.pctl.playing_state != 1 or self.pctl.track_queue[self.pctl.queue_step] != index):
-=======
+
 		if self.inp.mouse_wheel:
->>>>>>> e055b924 (Improved synced lyrics display)
 			scroll_distance = self.scroll.scroll("timed lyrics", 30*self.gui.scale)
 			if side_panel:
 				if self.coll((x, y, w, h)):
 					self.scroll_position += scroll_distance
 			else:
 				self.scroll_position += scroll_distance
-<<<<<<< HEAD
-=======
 			self.recenter_timeout.set()
->>>>>>> e055b924 (Improved synced lyrics display)
 
 		line_active = -1
 		last = -1

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -19590,8 +19590,8 @@ class TimedLyricsRen:
 
 		self.recenter_timeout = Timer()
 		self.temp_line: int = -1
-		self.temp_scale: float | None = None
-		self.temp_w: int | None = None
+		self.temp_scale: float = self.gui.scale
+		self.temp_w: int = -1
 
 	def generate(self, track: TrackClass) -> bool | None:
 		if self.index == track.index:


### PR DESCRIPTION
When displaying synced lyrics:
- you can click a line to teleport to it in the song
- you can scroll freely while the song is playing
- the view will snap back to default position after 5 seconds of not scrolling
- if the currently active lyric is not in the view, the view will not snap when active lyric advances
- spacing improved
- scrolling is bounded at the top and bottom of the lyrics

resolves #1653 