### PR TITLE
option to manually edit lyrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 ---------
 
 ### UPCOMING
+ - **Added** New fully-featured lyrics editor, including LRC support (thanks @rexendevar)
  - **Fixed** being able to click-to-seek synced lyrics even outside the lyrics window
  - **Fixed** Spotify playback via Librespot, regression introduced in 8.0.0
  - **Fixed** Jellyfin import, regression introduced in 8.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 ---------
 
 ### UPCOMING
+ - **Added** Menu option to manually edit track lyrics
+ - **Added** Option to automatically save changed lyrics back to the audio file
  - **Fixed** being able to click-to-seek synced lyrics even outside the lyrics window
  - **Fixed** Spotify playback via Librespot, regression introduced in 8.0.0
  - **Fixed** Jellyfin import, regression introduced in 8.1.0

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -19361,7 +19361,7 @@ class Drawing:
 		if w is None:
 			w = self.ddt.get_text_w(text, font) + 18 * self.gui.scale
 		if h is None:
-			h = 22 * self.gui.scale
+			h = self.ddt.get_text_w(text, font, True) + 6*self.gui.scale
 
 		rect = (x, y, w, h)
 		self.fields.add(rect)
@@ -19389,7 +19389,7 @@ class Drawing:
 			#	 background_highlight_colour = None
 
 			self.ddt.text(
-				(rect[0] + int(rect[2] / 2), rect[1] + 2 * self.gui.scale, 2), text, text_highlight_colour, font, bg=background_highlight_colour)
+				(rect[0] + int(rect[2] / 2), rect[1] + (rect[3]-6*self.gui.scale)/4, 2), text, text_highlight_colour, font, bg=background_highlight_colour)
 			if press:
 				click = True
 		else:
@@ -19397,7 +19397,7 @@ class Drawing:
 			if background_highlight_colour.a != 255:
 				background_colour = None
 			self.ddt.text(
-				(rect[0] + int(rect[2] / 2), rect[1] + 2 * self.gui.scale, 2), text, text_colour, font, bg=background_colour)
+				(rect[0] + int(rect[2] / 2), rect[1] + (rect[3]-6*self.gui.scale)/4, 2), text, text_colour, font, bg=background_colour)
 		return click
 
 class DropShadow:

--- a/src/tauon/t_modules/t_prefs.py
+++ b/src/tauon/t_modules/t_prefs.py
@@ -72,6 +72,7 @@ class Prefs:
 	tag_editor_target: str = ""
 	tag_editor_path:   str = ""
 	save_lyrics_to_file: bool = False
+	use_lrc_instead: bool = False
 
 	use_title:    bool = False
 	auto_extract: bool = False

--- a/src/tauon/t_modules/t_prefs.py
+++ b/src/tauon/t_modules/t_prefs.py
@@ -71,6 +71,7 @@ class Prefs:
 	tag_editor_name:   str = ""
 	tag_editor_target: str = ""
 	tag_editor_path:   str = ""
+	save_lyrics_to_file: bool = False
 
 	use_title:    bool = False
 	auto_extract: bool = False

--- a/src/tauon/t_modules/t_prefs.py
+++ b/src/tauon/t_modules/t_prefs.py
@@ -325,6 +325,8 @@ class Prefs:
 	autoscan_playlist_folder: bool = False
 	playlist_folder_path: str = ""
 
+	synced_lyrics_editor_track_end_mode: Literal["stop","autosave","full save"] = "stop"
+
 	sep_genre_multi = False
 	topchart_sorts_played = True
 


### PR DESCRIPTION
- new "edit lyrics" button option under "misc" when right clicking any lyrics
- new option in settings to save all lyrics changes back to original file (resolves #1723)

concerns/possible TODOs:
- add cancel [X] button beside "reload" ?
- how to deal with synced lyrics being returned from `get_lyric_fire`? do we write them to the normal `USLT` lyrics tag or do we figure out how to support `SYLT`?
- ~~is bare ID3 enough?? I struggled with Mutagen~~ FIXED for flac and m4a - ogg and ape are untested
- future big project - allow manual syncing of lyrics