### PR TITLE
Bump Windows ffmpeg to 7.1.1

### DIFF
--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -2342,7 +2342,7 @@ class PlayerCtl:
 		if self.prefs.art_bg or (self.gui.mode == 3 and self.prefs.mini_mode_mode == 5):
 			self.tauon.thread_manager.ready("style")
 
-	def get_url(self, track_object: TrackClass) -> tuple[str | None, dict | None] | None:
+	def get_url(self, track_object: TrackClass) -> tuple[list[str], str | None, dict | None] | None:
 		if track_object.file_ext == "TIDAL":
 			return self.tauon.tidal.resolve_stream(track_object), None
 		if track_object.file_ext == "PLEX":
@@ -5602,6 +5602,7 @@ class Tauon:
 		self.platform_system              = bag.platform_system
 		self.primary_stations             = bag.primary_stations
 		self.wayland                      = bag.wayland
+		self.msys                         = bag.msys
 		self.dirs                         = bag.dirs
 		self.colours                      = bag.colours
 		self.download_directories         = bag.download_directories
@@ -5677,7 +5678,6 @@ class Tauon:
 		self.quick_import_done: list[str] = []
 		self.move_jobs: list[tuple[str, str, bool, str, LoadClass]] = []
 		self.move_in_progress:       bool = False
-		self.msys                         = bag.msys
 		self.worker2_lock                 = threading.Lock()
 		self.dummy_event:          sdl3.SDL_Event = sdl3.SDL_Event()
 		self.temp_dest                            = sdl3.SDL_FRect(0, 0)
@@ -5942,7 +5942,6 @@ class Tauon:
 
 		self.chrome: Chrome | None = None
 		self.chrome_menu: Menu | None = None
-
 
 		self.tidal             = Tidal(self)
 		self.plex              = PlexService(self)
@@ -18215,34 +18214,34 @@ class Tauon:
 			self.show_message(_("FFMPEG could not be found"))
 		return False
 
-	def get_ffmpeg(self) -> str | None:
+	def get_ffmpeg(self) -> Path | None:
 		path = self.user_directory / "ffmpeg.exe"
 		if self.msys and path.is_file():
-			return str(path)
+			return path
 
 		# macOS
 		path = self.install_directory / "ffmpeg"
 		if path.is_file():
-			return str(path)
+			return path
 
 		path = shutil.which("ffmpeg")
 		if path:
-			return path
+			return Path(path)
 		return None
 
-	def get_ffprobe(self) -> str | None:
+	def get_ffprobe(self) -> Path | None:
 		path = self.user_directory / "ffprobe.exe"
 		if self.msys and path.is_file():
-			return str(path)
+			return path
 
 		# macOS
 		path = self.install_directory / "ffprobe"
 		if path.is_file():
-			return str(path)
+			return path
 
 		path = shutil.which("ffprobe")
 		if path:
-			return path
+			return Path(path)
 		return None
 
 	def bg_save(self) -> None:

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -14553,12 +14553,12 @@ class Tauon:
 
 	def download_ffmpeg(self, x) -> None:
 		def go() -> None:
-			url = "https://github.com/GyanD/codexffmpeg/releases/download/5.0.1/ffmpeg-5.0.1-essentials_build.zip"
-			sha = "9e00da9100ae1bba22b1385705837392e8abcdfd2efc5768d447890d101451b5"
+			url = "https://github.com/GyanD/codexffmpeg/releases/download/7.1.1/ffmpeg-7.1.1-essentials_build.zip"
+			sha = "04861d3339c5ebe38b56c19a15cf2c0cc97f5de4fa8910e4d47e5e6404e4a2d4"
 			self.show_message(_("Starting download..."))
 			try:
 				f = io.BytesIO()
-				r = requests.get(url, stream=True, timeout=1800) # ffmpeg is 77MB, give it half an hour in case someone is willing to suffer it on a slow connection
+				r = requests.get(url, stream=True, timeout=1800) # ffmpeg is 88MB, give it half an hour in case someone is willing to suffer it on a slow connection
 
 				dl = 0
 				for data in r.iter_content(chunk_size=4096):
@@ -14568,7 +14568,7 @@ class Tauon:
 					if mb > 90:
 						break
 					if mb % 5 == 0:
-						self.show_message(_("Downloading... {N}/80MB").format(N=mb))
+						self.show_message(_("Downloading... {N}/88MB").format(N=mb))
 
 			except Exception as e:
 				logging.exception("Download failed")
@@ -14581,11 +14581,11 @@ class Tauon:
 			self.show_message(_("Download completed.. extracting"))
 			f.seek(0)
 			z = zipfile.ZipFile(f, mode="r")
-			exe = z.open("ffmpeg-5.0.1-essentials_build/bin/ffmpeg.exe")
+			exe = z.open("ffmpeg-7.1.1-essentials_build/bin/ffmpeg.exe")
 			with (self.user_directory / "ffmpeg.exe").open("wb") as file:
 				file.write(exe.read())
 
-			exe = z.open("ffmpeg-5.0.1-essentials_build/bin/ffprobe.exe")
+			exe = z.open("ffmpeg-7.1.1-essentials_build/bin/ffprobe.exe")
 			with (self.user_directory / "ffprobe.exe").open("wb") as file:
 				file.write(exe.read())
 
@@ -18206,7 +18206,7 @@ class Tauon:
 		if self.get_ffmpeg():
 			return True
 		if self.msys:
-			self.show_message(_("This feature requires FFMPEG. Shall I can download that for you? (80MB)"), mode="confirm")
+			self.show_message(_("This feature requires FFMPEG. Shall I can download that for you? (88MB)"), mode="confirm")
 			self.gui.message_box_confirm_callback = self.download_ffmpeg
 			self.gui.message_box_no_callback = None
 			self.gui.message_box_confirm_reference = (None,)

--- a/src/tauon/t_modules/t_webserve.py
+++ b/src/tauon/t_modules/t_webserve.py
@@ -781,13 +781,12 @@ def authserve(tauon: Tauon) -> None:
 class VorbisMonitor:
 
 	def __init__(self) -> None:
-
-		self.tauon = None
+		self.tauon: Tauon | None = None
 		self.reset()
-		self.enable = True
-		self.synced = False
+		self.enable: bool = True
+		self.synced: bool = False
 		self.buffer = io.BytesIO()
-		self.tries = 0
+		self.tries: int = 0
 
 	def reset(self, tries: int = 0) -> None:
 		self.enable = True
@@ -796,7 +795,6 @@ class VorbisMonitor:
 		self.tries = tries
 
 	def input(self, data: bytes) -> None:
-
 		if not self.enable:
 			return
 


### PR DESCRIPTION
We still ship an ancient 5.x version at the moment.

Guts out #1598 to get the non-controversial changes from it.

This stops hardcoding the total filesize (except the initial prompt and fail of getting the size from the headers).

Stops hardcoding the exit to a certain filesize.