### PR TITLE
Fix master_library being loaded wrong

### DIFF
--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -40056,8 +40056,6 @@ def main(holder: Holder) -> None:
 	default_playlist: list[int] = []
 
 	# Library and loader Variables--------------------------------------------------------
-	master_library: dict[int, TrackClass] = {}
-
 	db_version: float = 0.0
 	latest_db_version: float = 73
 
@@ -40199,7 +40197,7 @@ def main(holder: Holder) -> None:
 		logical_size=logical_size,
 		window_size=window_size,
 		gen_codes={},
-		master_library=master_library,
+		master_library={},
 		loaded_asset_dc=loaded_asset_dc,
 		radio_playlist_viewing=0,
 		radio_playlists=radio_playlists,
@@ -40327,7 +40325,7 @@ def main(holder: Holder) -> None:
 				# gui.__init__()
 
 			if len(save) > 0 and save[0] is not None:
-				master_library = save[0]
+				bag.master_library = save[0]
 			bag.master_count = save[1]
 			bag.playlist_playing = save[2]
 			bag.active_playlist_viewing = save[3]
@@ -40647,7 +40645,7 @@ def main(holder: Holder) -> None:
 				for d in trackclass_jar:
 					nt = TrackClass()
 					nt.__dict__.update(d)
-					master_library[d["index"]] = nt
+					bag.master_library[d["index"]] = nt
 			if len(save) > 163 and save[163] is not None:
 				prefs.premium = save[163]
 			if len(save) > 164 and save[164] is not None:
@@ -40712,7 +40710,7 @@ def main(holder: Holder) -> None:
 	logging.info(f"Database loaded in {round(perf_timer.get(), 3)} seconds.")
 
 	perf_timer.set()
-	keys = set(master_library.keys())
+	keys = set(bag.master_library.keys())
 	for pl in bag.multi_playlist:
 		if db_version > 68 or db_version == 0:
 			keys -= set(pl.playlist_ids)
@@ -40933,10 +40931,10 @@ def main(holder: Holder) -> None:
 	if db_version > 0 and db_version < latest_db_version:
 		logging.warning(f"Current DB version {db_version} was lower than latest {latest_db_version}, running migrations!")
 		try:
-			master_library, pctl.multi_playlist, tauon.star_store, pctl.force_queue, prefs.theme, prefs, gui, pctl.gen_codes, pctl.radio_playlists = database_migrate(
+			pctl.master_library, pctl.multi_playlist, tauon.star_store, pctl.force_queue, prefs.theme, prefs, gui, pctl.gen_codes, pctl.radio_playlists = database_migrate(
 				tauon=tauon,
 				db_version=db_version,
-				master_library=master_library,
+				master_library=pctl.master_library,
 				install_mode=install_mode,
 				multi_playlist=pctl.multi_playlist,
 				star_store=tauon.star_store,


### PR DESCRIPTION
It seems we were loading `master_library` into `master_library` but pctl was initializing with it from Bag, which would be empty...