### PR TITLE
Fix typing and add back X11 fallback removal

### DIFF
--- a/src/tauon/__main__.py
+++ b/src/tauon/__main__.py
@@ -362,8 +362,27 @@ if not t_window:
 	logging.error(f"Size 0: {logical_size[0]}")
 	logging.error(f"Size 1: {logical_size[1]}")
 	logging.error(f"Flags: {flags}")
-	logging.error(f"SDL Error: {sdl3.SDL_GetError()}")
-	sys.exit(1)
+	sdl_err = sdl3.SDL_GetError()
+	logging.error(f"SDL Error: {sdl_err}")
+	if sdl_err and sdl_err.decode() == "x11 not available":
+		x11_path = user_directory / "x11"
+		if x11_path.exists():
+			logging.critical("Disabled Xwayland preference as X11 was not found - Known issue if on Flatpak - https://github.com/Taiko2k/Tauon/issues/1034")
+			x11_path.unlink()
+			# TODO(Martin): This does not seem to work on SDL3, it attempts to relaunch under x11 again
+			#os.environ["SDL_VIDEODRIVER"] = "wayland"
+			#t_window = sdl3.SDL_CreateWindow(
+			#	window_title,
+			#	o_x, o_y,
+			#	logical_size[0], logical_size[1],
+			#	flags)
+			#if not t_window:
+			#	logging.error(f"Failed to create Wayland fallback window - SDL Error: {sdl3.SDL_GetError()}")
+			#	sys.exit(1)
+			sys.exit(1)
+		else:
+			logging.critical(f"Failed to find {x11_path} but got 'x11 not available' error, hm?")
+			sys.exit(1)
 
 if maximized:
 	sdl3.SDL_MaximizeWindow(t_window)

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -22056,7 +22056,7 @@ class ToolTip:
 		self.called = False
 		self.a = False
 
-	def test(self, x: float, y: float, text: string) -> None:
+	def test(self, x: float, y: float, text: str) -> None:
 		if self.text != text or x != self.x or y != self.y:
 			self.text = text
 			# self.timer.set()
@@ -22477,7 +22477,7 @@ class TransEditBox:
 			if len(select) > 1:
 				self.active_field = 1
 
-		def field_edit(x: int, y: int, label: string, field_number: int, names: list[str], text_box: TextBox2) -> bool:
+		def field_edit(x: int, y: int, label: str, field_number: int, names: list[str], text_box: TextBox2) -> bool:
 			changed = False
 			self.ddt.text((x, y), label, self.colours.box_text_label, 11)
 			y += round(16 * self.gui.scale)


### PR DESCRIPTION
This was removed during migration to SDL3 but it is still useful.

I was not able to figure out why `SDL_VIDEODRIVER` is now ignored but I haven't really tried hard, so for now we just unlink the file and don't attempt to re-launch.