### PR TITLE
fix timing scroll shortly after manually scrolling

### DIFF
--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -37530,7 +37530,6 @@ class TimedLyricsEdit:
 			else:
 				full_line = ( self.get_stamp_from_time(time), time, self.structure[self.line_active+1][2] ) # else time the next line
 				self.structure[self.line_active+1] = full_line
-			self.scroll_position -= self.yy
 		self.queue_next_frame = True
 
 	def scroll_timestamp(self, current_line: int, active: bool = True) -> bool | None:


### PR DESCRIPTION
previously in the synced editor you could scroll with the mouse wheel, then use the enter key and the active line would jump upwards. no longer