### PR TITLE
fixing a couple issues with saving lyrics

### DIFF
--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -38223,7 +38223,7 @@ class TimedLyricsEdit:
 		if self.prefs.synced_lyrics_editor_track_end_mode == "stop" or self.prefs.synced_lyrics_editor_track_end_mode == "repeat" and self.pctl.playing_state == PlayingState.PLAYING:
 			if self.pctl.playing_length - self.pctl.decode_time < 5.5:
 				self.queue_next_frame = True
-			if self.pctl.playing_length - self.pctl.decode_time < 2.01:
+			if self.pctl.playing_length - self.pctl.decode_time < 2.1:
 				if self.prefs.synced_lyrics_editor_track_end_mode == "stop":
 					self.pctl.stop()
 				elif not self.repeat_mode: # repeat

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -7794,7 +7794,7 @@ class Tauon:
 
 			if stop:
 				self.pctl.jump_time = self.pctl.decode_time
-				self.pctl.stop()
+				self.pctl.stop(block=True)
 			audio.save()
 			logging.info(f"Edited lyrics in the file for {track.artist} - {track.title}")
 			if resume:

--- a/src/tauon/t_modules/t_prefs.py
+++ b/src/tauon/t_modules/t_prefs.py
@@ -330,6 +330,7 @@ class Prefs:
 	playlist_folder_path: str = ""
 
 	synced_lyrics_editor_track_end_mode: Literal["stop","autosave","full save","repeat"] = "repeat"
+	save_lyrics_changes_to_files: bool = False
 
 	sep_genre_multi = False
 	topchart_sorts_played = True

--- a/src/tauon/t_modules/t_prefs.py
+++ b/src/tauon/t_modules/t_prefs.py
@@ -329,7 +329,7 @@ class Prefs:
 	autoscan_playlist_folder: bool = False
 	playlist_folder_path: str = ""
 
-	synced_lyrics_editor_track_end_mode: Literal["stop", "autosave", "full save"] = "stop"
+	synced_lyrics_editor_track_end_mode: Literal["stop","autosave","full save","repeat"] = "repeat"
 
 	sep_genre_multi = False
 	topchart_sorts_played = True


### PR DESCRIPTION
 - [x] bug that removes random tracks from playlists when saving lyrics
original pr text:
I'm still not sure whether the tracks were being deleted from playlists or from the whole database or what. Stopping the currently playing song before writing to it might fix it. If I still get the same bug, I'll attack it again by replacing play() with a modified version of play_target() that should fully reopen the file.
 - [x] add option for automatically saving "simple" lyrics edits (clear, search etc rather than from the editor) rather than mandating it
 - [ ] add waitlist to autosave simple lyrics edits rather than block stopping playback to do so
 - [x] avoid running track end behavior on manual skip
 - [x] "repeat track" as new default track end behavior