### PR TITLE
Fix crash when saving lyrics

### DIFF
--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -37433,19 +37433,19 @@ class TimedLyricsEdit:
 				return True
 		elif track.file_ext == "FLAC":
 			audio = mutagen.flac.FLAC(track.fullpath)
-			if audio["LYRICS"]:
+			if "LYRICS" in audio:
 				return True
 		elif track.file_ext in ("OPUS", "OGG"):
 			audio = mutagen.oggvorbis.OggVorbis(track.fullpath)
-			if audio["LYRICS"]:
+			if "LYRICS" in audio:
 				return True
 		elif track.file_ext in ("APE","WV","TTA"):
 			audio = mutagen.apev2.APEv2(track.fullpath)
-			if audio["Lyrics"]:
+			if "Lyrics" in audio:
 				return True
 		elif track.file_ext in ("MP4","M4A","M4B","M4P"):
 			audio = mutagen.mp4.MP4(track.fullpath)
-			if audio['\xa9lyr']:
+			if '\xa9lyr' in audio:
 				return True
 		return False
 


### PR DESCRIPTION
Fixes

```python
Traceback (most recent call last):
  File "/home/user/Projects/Tauon/src/tauon/__main__.py", line 500, in <module>
    main()
    ~~~~^^
  File "/home/user/Projects/Tauon/src/tauon/__main__.py", line 79, in main
    t_main(holder)
    ~~~~~~^^^^^^^^
  File "/home/user/Projects/Tauon/src/tauon/t_modules/t_main.py", line 46797, in main
    showcase.render()
    ~~~~~~~~~~~~~~~^^
  File "/home/user/Projects/Tauon/src/tauon/t_modules/t_main.py", line 35781, in render
    self.timed_lyrics_edit.render()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/userProjects/Tauon/src/tauon/t_modules/t_main.py", line 38510, in render
    self.synced_render(track.index, gcx, y, hide_art, w)
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/userProjects/Tauon/src/tauon/t_modules/t_main.py", line 38042, in synced_render
    self.save()
    ~~~~~~~~~^^
  File "/home/userProjects/Tauon/src/tauon/t_modules/t_main.py", line 37346, in save
    over = self.will_overwrite_lyrics(track)
  File "/home/userProjects/Tauon/src/tauon/t_modules/t_main.py", line 37436, in will_overwrite_lyrics
    if audio["LYRICS"]:
       ~~~~~^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/mutagen/_file.py", line 63, in __getitem__
    return self.tags[key]
           ~~~~~~~~~^^^^^
  File "/usr/lib/python3.13/site-packages/mutagen/_vorbis.py", line 241, in __getitem__
    raise KeyError(key)
KeyError: 'lyrics'
```