### PR TITLE
Use Jellyfin's NormalizationGain as replaygain_track_gain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changelog
  - **Added** Option to upload lyrics to LRCLIB (inside the lyrics editor)
  - **Added** All lyrics changes will now write back to their original files
  - **Added** Spring-loaded clicking behavior to all context menus
+ - **Added** Track ReplayGain support for Jellyfin
  - **Fixed** Setting "Background artist info download" not being respected
  - **Fixed** Chart generation on macOS and Windows (regression)
  - **Fixed** Loading queue on app restart (regression)

--- a/src/tauon/t_modules/t_jellyfin.py
+++ b/src/tauon/t_modules/t_jellyfin.py
@@ -484,6 +484,9 @@ class Jellyfin:
 				if len(artists) > 1:
 					nt.misc["artists"] = artists
 				nt.album_artist = track.get("AlbumArtist", "")
+				replay_gain = track.get("NormalizationGain", "")
+				if replay_gain:
+					nt.misc["replaygain_track_gain"] = float(replay_gain)
 				nt.title = track.get("Name", "")
 				nt.composer = "; ".join(d["Name"]
 					for d in track.get("People", [])


### PR DESCRIPTION
Fixes #1087

I am not sure if I did this correctly, as Jellyfin only gives one value for normalization gain.

Seems to work, though?

```
2025-09-25 13:17:26 [ DEBUG ] [ t_phazor ] Detected Replay gain (t_phazor.py:603)
2025-09-25 13:17:26 [ DEBUG ] [ t_phazor ] GAIN: -12.78 (t_phazor.py:604)
2025-09-25 13:17:26 [ DEBUG ] [ t_phazor ] PEAK: 1 (t_phazor.py:605)
2025-09-25 13:17:26 [ DEBUG ] [ t_phazor ] FINAL: 0.2296148648112362 (t_phazor.py:606)
```