### PR TITLE
Prefer using the track's main/first artist to fetch info about the artist.

### DIFF
--- a/src/tauon/t_modules/t_extra.py
+++ b/src/tauon/t_modules/t_extra.py
@@ -1016,7 +1016,7 @@ def get_first_artist(artist: str) -> str:
 		if idx != -1:
 			artist = artist[:idx]
 			break
-	return artist.strip()
+	return artist.replace("/", "").replace("\\", "").strip()
 
 
 def get_split_artists(track: TrackClass) -> list[str]:

--- a/src/tauon/t_modules/t_extra.py
+++ b/src/tauon/t_modules/t_extra.py
@@ -1008,6 +1008,17 @@ def get_artist_safe(track: TrackClass | None) -> str:
 	return ""
 
 
+def get_first_artist(artist: str) -> str:
+	if not artist:
+		return ""
+	for sep in (" & ", " &", " ; ", ";", "ft. ", " feat. ", " feat(", ", ", ","):
+		idx = artist.find(sep)
+		if idx != -1:
+			artist = artist[:idx]
+			break
+	return artist.strip()
+
+
 def get_split_artists(track: TrackClass) -> list[str]:
 	if "artists" in track.misc:
 		return track.misc["artists"]

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -4352,7 +4352,7 @@ class LastFMapi:
 		if self.lastfm_network is None and self.last_fm_only_connect() is False:
 			return ""
 
-		artist_object = pylast.Artist(artist, self.lastfm_network)
+		artist_object = pylast.Artist(get_first_artist(artist), self.lastfm_network)
 		bio = artist_object.get_bio_summary(language="en")
 		# logging.info(artist_object.get_cover_image())
 		# logging.info("\n\n")

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -37813,7 +37813,7 @@ class ArtistInfoBox:
 			return
 
 		# Check if the artist has changed
-		self.artist_on = track.artist
+		self.artist_on = get_first_artist(track.artist)
 
 		if not self.lock and self.artist_on:
 			self.lock = True
@@ -37841,7 +37841,7 @@ class ArtistInfoBox:
 			return
 
 		# Check if the artist has changed
-		artist = track.artist
+		artist = get_first_artist(track.artist)
 		wait = False
 
 		# Activate menu

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -151,6 +151,7 @@ from tauon.t_modules.t_extra import (  # noqa: E402
 	genre_correct,
 	get_artist_safe,
 	get_artist_strip_feat,
+	get_first_artist,
 	get_display_time,
 	get_filesize_string,
 	get_filesize_string_rounded,
@@ -4227,9 +4228,7 @@ class LastFMapi:
 
 		try:
 			if artist:
-				l_artist = pylast.Artist(
-					artist.replace("/", "").replace("\\", "").replace(" & ", " and ").replace("&", " "),
-					self.lastfm_network)
+				l_artist = pylast.Artist(get_first_artist(artist), self.lastfm_network)
 				bio = l_artist.get_bio_content()
 				# cover_link = l_artist.get_cover_image()
 				mbid = l_artist.get_mbid()
@@ -4247,9 +4246,7 @@ class LastFMapi:
 
 		try:
 			if artist:
-				l_artist = pylast.Artist(
-					artist.replace("/", "").replace("\\", "").replace(" & ", " and ").replace("&", " "),
-					self.lastfm_network)
+				l_artist = pylast.Artist(get_first_artist(artist), self.lastfm_network)
 				return l_artist.get_mbid()
 		except Exception:
 			logging.exception("last.fm get artist mbid info failed")


### PR DESCRIPTION
Adds a new small function in t_extra that sanitizes artist strings, replacing the inline operation: `pylast.Artist(artist.replace("/", "").replace("\\", "").replace(" & ", " and ").replace("&", " ")...`

Makes changes in artist_info, artist_mbid and get_bio (which previously was inconsistent) to use the main/first artist instead of the whole artist string.

Before:
"Danny Brown & underscores" fetches "Danny Brown and underscores" = No information.

After:
"Danny Brown & underscores" fetches "Danny Brown" = Gets Danny Brown's bio.

Note that there's a _very small_ chance that some bad formatted track data could have the main artist as second, fetching the secondary artist as first. But honestly, that's beyond the scope of what the player can infer.