### PR TITLE
Add support for reloading the theme from command line

### DIFF
--- a/src/tauon/__main__.py
+++ b/src/tauon/__main__.py
@@ -178,6 +178,9 @@ def transfer_args_and_exit() -> None:
 		if item == "--repeat":
 			url = base + "repeat/"
 			urllib.request.urlopen(url)
+		if item == "--reload-theme":
+			url = base + "reloadtheme/"
+			urllib.request.urlopen(url)
 
 	sys.exit()
 

--- a/src/tauon/t_modules/t_webserve.py
+++ b/src/tauon/t_modules/t_webserve.py
@@ -1093,6 +1093,8 @@ def controller(tauon: Tauon) -> None:
 				tauon.toggle_random()
 			if path == "/repeat":
 				tauon.toggle_repeat()
+			if path == "/reloadtheme":
+				tauon.load_theme()
 			if path.startswith("/open/"):
 				rest = path[6:]
 				try:

--- a/src/tauon/t_modules/t_webserve.py
+++ b/src/tauon/t_modules/t_webserve.py
@@ -1093,8 +1093,6 @@ def controller(tauon: Tauon) -> None:
 				tauon.toggle_random()
 			if path == "/repeat":
 				tauon.toggle_repeat()
-			if path == "/reloadtheme":
-				tauon.load_theme()
 			if path.startswith("/open/"):
 				rest = path[6:]
 				try:


### PR DESCRIPTION
This solves the problem I brought up in the issue #2156

## What it does:

This PR allows the user to run `tauon --reload-theme` to make tauon (re)load its theme.

## Why:

I use a dynamically generated `wallpaper.ttheme` file that is overwritten on wallpaper change.
Having this feature allows my theme-generation script to also tell tauon to reload its theme (instead of having to manually press F10).

## Note:

- In my original issue, I suggested watching theme file change; but after a quick code review, I figured that this solution fits the existing code base a lot better, so I went with that.
- I noticed lines like `elif path == "/api1/<argument>":` in `src/tauon/t_modules_t_webserve.py` (`doGet` function) that look a lot like the ones I added, but did not touch them because (1) I am not familiar enough with the code and (2) figured there's no use in adding support for remotely reloading the theme.   