### PR TITLE
Improve Genius lyrics coverage with API search fallback

### DIFF
--- a/src/tauon/t_modules/t_lyrics.py
+++ b/src/tauon/t_modules/t_lyrics.py
@@ -47,32 +47,46 @@ def ovh(
 	return "", ""
 
 
-def genius(
-	artist: str,
-	title: str,
-	return_url: bool = False,
-	user_agent: str = "unused here but it needs to exist in every lyrics function",
-) -> tuple[str, str] | str:
-	"""Scrape lyrics from genius.com"""
-	artist = artist.split("feat.", maxsplit=1)[0].strip()
-	title = title.split("(feat.", maxsplit=1)[0].strip()
-	line = f"{artist}-{title}"
-	line = re.sub("[,._@!#%^*+:;'()]", "", line)
-	line = line.replace("]", "")
-	line = line.replace("[", "")
-	line = line.replace("?", "")
-	line = line.replace(" ", "-")
-	line = line.replace("/", "-")
-	line = line.replace("-&-", "-and-")
-	line = line.replace("&", "-and-")
-	line = unidecode(line)
-	line = urllib.parse.quote(line)
-	line = f"https://genius.com/{line}-lyrics"
+def _genius_search(artist: str, title: str) -> str:
 
-	if return_url:
-		return line
+	query = f"{artist} {title}"
+	url = "https://genius.com/api/search/song"
+	params = {"page": 1, "q": query}
+	try:
+		r = requests.get(url, params=params, timeout=10)
+		if r.status_code != HTTPStatus.OK:
+			return ""
+		data = r.json()
+		hits = []
+		for section in data.get("response", {}).get("sections", []):
+			if section.get("type") == "song":
+				hits.extend(section.get("hits", []))
+		if not hits:
+			return ""
+		artist_lower = artist.strip().lower()
+		title_lower = title.strip().lower()
+		for hit in hits:
+			result = hit.get("result", {})
+			song_artist = result.get("artist_names", "").lower()
+			song_title = result.get("title", "").lower()
+			if (artist_lower in song_artist or song_artist in artist_lower) \
+				and (title_lower in song_title or song_title in title_lower):
+				return result.get("url", "")
+		return hits[0].get("result", {}).get("url", "")
+	except Exception:
+		logging.exception("Genius search failed")
+		return ""
 
-	page = requests.get(line, timeout=10)
+
+def _genius_scrape(url: str) -> tuple[str, str]:
+
+	try:
+		page = requests.get(url, timeout=10)
+		if page.status_code != HTTPStatus.OK:
+			return "", ""
+	except Exception:
+		return "", ""
+
 	html = BeautifulSoup(page.text, "html.parser")
 
 	result = html.find("div", class_="lyrics")
@@ -180,6 +194,42 @@ def genius(
 		return final_lyrics, ""
 
 	return "", ""
+
+
+def genius(
+	artist: str,
+	title: str,
+	return_url: bool = False,
+	user_agent: str = "unused here but it needs to exist in every lyrics function",
+) -> tuple[str, str] | str:
+	"""Scrape lyrics from genius.com"""
+	artist = artist.split("feat.", maxsplit=1)[0].strip()
+	title = title.split("(feat.", maxsplit=1)[0].strip()
+	line = f"{artist}-{title}"
+	line = re.sub("[,._@!#%^*+:;'()]", "", line)
+	line = line.replace("]", "")
+	line = line.replace("[", "")
+	line = line.replace("?", "")
+	line = line.replace(" ", "-")
+	line = line.replace("/", "-")
+	line = line.replace("-&-", "-and-")
+	line = line.replace("&", "-and-")
+	line = unidecode(line)
+	line = urllib.parse.quote(line)
+	line = f"https://genius.com/{line}-lyrics"
+
+	if return_url:
+		return line
+
+	lyrics, synced = _genius_scrape(line)
+	if lyrics:
+		return lyrics, synced
+
+	line = _genius_search(artist, title)
+	if not line:
+		return "", ""
+
+	return _genius_scrape(line)
 
 
 def lrclib(artist: str, title: str, user_agent: str = "TauonMusicBox/Devel") -> tuple[str, str]:


### PR DESCRIPTION
Hi, I really loved this music player for it's minimalist design and that it runs smooth on CachyOS, and i would love to contribute to this project, so i thought of first contributing to one of the good first issues mentioned, and so i picked #1002 , and did my best to improve the Genius scraping algorithm:

The Genius scraper previously constructed [https://genius.com/{slugified-artist}-{slugified-title}-lyrics](https://genius.com/%7Bslugified-artist%7D-%7Bslugified-title%7D-lyrics) to search for lyrics, and failed silently whenever the slug didn't match the actual URL, which is common with song titles having featured artists (Ft. ...), special characters, Unicode, romanized titles, ampersands, etc.

Fix: when the direct URL returns nothing, we can fall back to genius.com/api/search/song to find the correct page. I refactored the old monolithic function into _genius_scrape(url) + _genius_search(artist, title) + genius() entry point, which I partly derived from the Strawberry Music Player's repo.

To test both, the testing script makes a 500-song corpus by searching Genius for the SEED terms (set of keywords), caching results to genius_corpus.json. Then for each song, it runs the old direct-URL provider and the new search-fallback provider, measuring wall time and lyrics length. It then writes to a per-song CSV log to genius_test.log and prints a final coverage summary (old %, new %, delta in percentage points) in the terminal output.

The testing script ran for 1604 seconds (~27 min) and the results were:
Old provider: 385/500 (77.0%)
New provider: 496/500 (99.2%) [+22.2% improvement]
0 regressions (all 385 songs the old one got are also got by the new one)
Here's the log file [genius_test.log](https://github.com/user-attachments/files/28494417/genius_test.log), and the corpus if needed [genius_corpus.json](https://github.com/user-attachments/files/28494623/genius_corpus.json)

To reproduce, I have attached the testing script here: [test_lyrics_coverage_v2.py](https://github.com/user-attachments/files/28494421/test_lyrics_coverage_v2.py)

Usage:
pip install requests beautifulsoup4 unidecode
python3 test_lyrics_coverage_v2.py