### PR TITLE
Fix #384 and #1023

### DIFF
--- a/src/tauon/t_modules/t_lyrics.py
+++ b/src/tauon/t_modules/t_lyrics.py
@@ -47,32 +47,46 @@ def ovh(
 	return "", ""
 
 
-def genius(
-	artist: str,
-	title: str,
-	return_url: bool = False,
-	user_agent: str = "unused here but it needs to exist in every lyrics function",
-) -> tuple[str, str] | str:
-	"""Scrape lyrics from genius.com"""
-	artist = artist.split("feat.", maxsplit=1)[0].strip()
-	title = title.split("(feat.", maxsplit=1)[0].strip()
-	line = f"{artist}-{title}"
-	line = re.sub("[,._@!#%^*+:;'()]", "", line)
-	line = line.replace("]", "")
-	line = line.replace("[", "")
-	line = line.replace("?", "")
-	line = line.replace(" ", "-")
-	line = line.replace("/", "-")
-	line = line.replace("-&-", "-and-")
-	line = line.replace("&", "-and-")
-	line = unidecode(line)
-	line = urllib.parse.quote(line)
-	line = f"https://genius.com/{line}-lyrics"
+def _genius_search(artist: str, title: str) -> str:
 
-	if return_url:
-		return line
+	query = f"{artist} {title}"
+	url = "https://genius.com/api/search/song"
+	params = {"page": 1, "q": query}
+	try:
+		r = requests.get(url, params=params, timeout=10)
+		if r.status_code != HTTPStatus.OK:
+			return ""
+		data = r.json()
+		hits = []
+		for section in data.get("response", {}).get("sections", []):
+			if section.get("type") == "song":
+				hits.extend(section.get("hits", []))
+		if not hits:
+			return ""
+		artist_lower = artist.strip().lower()
+		title_lower = title.strip().lower()
+		for hit in hits:
+			result = hit.get("result", {})
+			song_artist = result.get("artist_names", "").lower()
+			song_title = result.get("title", "").lower()
+			if (artist_lower in song_artist or song_artist in artist_lower) \
+				and (title_lower in song_title or song_title in title_lower):
+				return result.get("url", "")
+		return hits[0].get("result", {}).get("url", "")
+	except Exception:
+		logging.exception("Genius search failed")
+		return ""
 
-	page = requests.get(line, timeout=10)
+
+def _genius_scrape(url: str) -> tuple[str, str]:
+
+	try:
+		page = requests.get(url, timeout=10)
+		if page.status_code != HTTPStatus.OK:
+			return "", ""
+	except Exception:
+		return "", ""
+
 	html = BeautifulSoup(page.text, "html.parser")
 
 	result = html.find("div", class_="lyrics")
@@ -180,6 +194,42 @@ def genius(
 		return final_lyrics, ""
 
 	return "", ""
+
+
+def genius(
+	artist: str,
+	title: str,
+	return_url: bool = False,
+	user_agent: str = "unused here but it needs to exist in every lyrics function",
+) -> tuple[str, str] | str:
+	"""Scrape lyrics from genius.com"""
+	artist = artist.split("feat.", maxsplit=1)[0].strip()
+	title = title.split("(feat.", maxsplit=1)[0].strip()
+	line = f"{artist}-{title}"
+	line = re.sub("[,._@!#%^*+:;'()]", "", line)
+	line = line.replace("]", "")
+	line = line.replace("[", "")
+	line = line.replace("?", "")
+	line = line.replace(" ", "-")
+	line = line.replace("/", "-")
+	line = line.replace("-&-", "-and-")
+	line = line.replace("&", "-and-")
+	line = unidecode(line)
+	line = urllib.parse.quote(line)
+	line = f"https://genius.com/{line}-lyrics"
+
+	if return_url:
+		return line
+
+	lyrics, synced = _genius_scrape(line)
+	if lyrics:
+		return lyrics, synced
+
+	line = _genius_search(artist, title)
+	if not line:
+		return "", ""
+
+	return _genius_scrape(line)
 
 
 def lrclib(artist: str, title: str, user_agent: str = "TauonMusicBox/Devel") -> tuple[str, str]:

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -51221,7 +51221,7 @@ def main(holder: Holder) -> None:
 											x + tauon.album_mode_art_size, window_size[0] - round(50 * gui.scale)
 										)
 
-									if info[0] == 1 and (
+									if info[0] == 1 and not info[2] and (
 										pctl.playing_state in (PlayingState.PLAYING, PlayingState.PAUSED)
 									):
 										ddt.rect_a(

--- a/src/tauon/t_modules/t_phazor.py
+++ b/src/tauon/t_modules/t_phazor.py
@@ -460,7 +460,29 @@ def phazor_exists(pctl: PlayerCtl) -> bool:
 	return get_phazor_path(pctl).exists()
 
 
+_consecutive_load_failures: int = 0
+_load_failure_timer: Timer = Timer()
+MAX_CONSECUTIVE_LOAD_FAILURES: int = 5
+LOAD_FAILURE_WINDOW: float = 3.0
+
+
 def player4(tauon: Tauon) -> None:
+	global _consecutive_load_failures
+
+	def _handle_load_failure() -> bool:
+		global _consecutive_load_failures
+		if _load_failure_timer.get() > LOAD_FAILURE_WINDOW:
+			_consecutive_load_failures = 0
+		_consecutive_load_failures += 1
+		_load_failure_timer.set()
+		if _consecutive_load_failures >= MAX_CONSECUTIVE_LOAD_FAILURES:
+			pctl.stop(run=True)
+			if not gui.message_box:
+				tauon.show_message(_("Multiple tracks could not be loaded"), mode="warning")
+			_consecutive_load_failures = 0
+			return True
+		return False
+
 	def scan_device() -> None:
 		n = aud.scan_devices()
 		devices = ["Default"]
@@ -964,6 +986,8 @@ def player4(tauon: Tauon) -> None:
 						target_object.found = False
 						pctl.playing_state = PlayingState.STOPPED
 						pctl.jump_time = 0.0
+						if _handle_load_failure():
+							continue
 						pctl.advance(inplace=True, play=True)
 						continue
 					target_path = path
@@ -973,8 +997,11 @@ def player4(tauon: Tauon) -> None:
 					if not target_object.is_network:
 						pctl.playing_state = PlayingState.STOPPED
 						pctl.jump_time = 0.0
+						if _handle_load_failure():
+							continue
 						pctl.advance(inplace=True, play=True)
 					continue
+				_consecutive_load_failures = 0
 				if not target_object.found:
 					pctl.reset_missing_flags()
 


### PR DESCRIPTION
Fixing old, open issues

## #384  — Fix runaway track cycling on missing files

When a track file is unavailable (e.g., external drive not mounted), Tauon calls `pctl.advance(inplace=True, play=True)` unconditionally, which re-queues the next track and triggers another load attempt. If that track is also missing, the cycle repeats at ~60 Hz (the phazor thread's tick rate), which causes the strange glitch cycling through music very fast issue.

Fix: added a consecutive-fail counter (`_consecutive_load_failures`) with a 3-second time window in `t_phazor.py`. After 5 consecutive load failures within 3 seconds, playback stops via `pctl.stop(run=True)` and a warning toast is shown. The counter resets on each successful load, so single bad files still auto-skip as before.
(I'm not sure if the ratio of songs to the time window is good enough for such cases, would like some feedback regarding it)

## #1023  — Fix double highlight in gallery view

In gallery (album art grid) view, two albums could show selection borders simultaneously. The playing-border condition at `t_main.py:51224` drew unconditionally on the currently-playing album regardless of `album_tab_mode`, while the selection border at line 51280 drew on the selected album when `album_tab_mode` was active. When the user selected an album different from the playing one, both borders appeared.

Fix: added `and not info[2]` to the playing border condition, suppressing it on the currently-selected album so the selection border is the only highlight.