### PR TITLE
Fix network stream playback: progress bar drift, silent transitions, and 98% progress

### DIFF
--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -3311,7 +3311,8 @@ class PlayerCtl:
 		#	 #self.gui.update += 1
 		#	 self.playing_time_int = next_round
 
-		gap_extra = 2  # 2
+		tr = self.playing_object()
+		gap_extra = 2 if not (tr and tr.is_network) else 0
 
 		if self.tauon.chrome_mode:
 			gap_extra = 3

--- a/src/tauon/t_modules/t_phazor.py
+++ b/src/tauon/t_modules/t_phazor.py
@@ -1043,6 +1043,7 @@ def player4(tauon: Tauon) -> None:
 
 				fade = 0
 				error = False
+				target_fully_cached = not target_object.is_network or cachement.get_file_cached_only(target_object) is not None
 				if (
 					tauon.player4_state == PlayerState.PLAYING
 					and length
@@ -1052,7 +1053,7 @@ def player4(tauon: Tauon) -> None:
 					and loaded_track
 					and 0 < remain < 5.5
 					and not loaded_track.is_cue
-					and not loaded_track.is_network
+					and target_fully_cached
 					and subcommand != "now"
 				):
 					logging.info("Transition gapless")

--- a/src/tauon/t_modules/t_phazor.py
+++ b/src/tauon/t_modules/t_phazor.py
@@ -1052,6 +1052,7 @@ def player4(tauon: Tauon) -> None:
 					and loaded_track
 					and 0 < remain < 5.5
 					and not loaded_track.is_cue
+					and not loaded_track.is_network
 					and subcommand != "now"
 				):
 					logging.info("Transition gapless")
@@ -1307,6 +1308,7 @@ def player4(tauon: Tauon) -> None:
 
 				pctl.decode_time = pctl.playing_time
 				wall_timer.set()
+				player_timer.set()
 
 			if command == "volume":
 				aud.ramp_volume(int(pctl.player_volume), 750)


### PR DESCRIPTION
Fixes #449 and Fixes #788 

### Problem

Network streams (Jellyfin, Subsonic, Tidal) via the PHAzOR backend had three related issues:

**#788 — Progress bar drifts after seeking:** After clicking the progress bar to seek, `player_timer` wasn't reset. The next `track()` call accumulated stale time from `player_timer.hit()` into `pctl.playing_time`, causing the progress bar to drift by up to 2 seconds. Tracks appeared to end early.

**#449 — No sound after a track finishes:** Gapless transitions fired for network streams, calling `aud.next()` with a cached file path. The C backend's `load_next()` → `uni_fopen()` failed because the cached file was pruned or not yet downloaded, producing "Error opening file" and silent playback.

**Progress bar stops at ~98%:** `gap_extra = 2` in `test_progress()` advances tracks 2 seconds before the metadata end. For local files this enables gapless; for network tracks (which don't use gapless) it just makes the bar stop short.

### Fix

**#449 — `t_phazor.py:1055`** — Added `and not loaded_track.is_network` to the gapless transition condition. Network tracks now use the reliable "Transition jump" path via `aud.start()` instead of the broken gapless `aud.next()` path.

**#788 — `t_phazor.py:1311`** — Added `player_timer.set()` after the seek command handler. Resets the timer so `track()` doesn't accumulate stale time after seeking.

**Progress bar — `t_main.py:3314`** — Set `gap_extra = 0` for network tracks. Since network tracks don't use gapless, the 2-second buffer is unnecessary and causes the bar to stop at ~98%.

### The Journey

These fixes went through several iterations. The initial approach for #788 added `set_length_ms()` to `phazor.c` to sync track length from metadata into the C backend. It compiled and exported correctly, but rebuilding `phazor-pw.so` (the PipeWire variant) broke audio output entirely — progress moved but no sound played. The distro-built PipeWire `.so` has different internals than a manual `gcc -shared` build. After reverting all C changes, the solution was found purely in Python: resetting `player_timer` after seek and letting the existing metadata-based `pctl.playing_length` handle the rest. Similarly, #449's fix is a single boolean guard that sidesteps the C-level race condition entirely.

### Testing

- `python3 -m py_compile src/tauon/t_modules/t_phazor.py` — passes
- `python3 -m py_compile src/tauon/t_modules/t_main.py` — passes
- Runtime: play Jellyfin tracks, verify progress bar reaches 100%, seek works correctly, tracks advance without silence
