### PR TITLE
Fix radio streaming: BrokenPipeError crashes and websocket connection errors on station switching

### DIFF
--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -35125,7 +35125,10 @@ class RadioBox:
 			def send_heartbeat(ws: WebSocketApp) -> None:
 				#logging.info(self.ws_interval)
 				time.sleep(self.ws_interval)
-				ws.send("{\"op\":9}")
+				try:
+					ws.send('{"op":9}')
+				except Exception:
+					logging.info("Websocket already closed")
 				logging.info("Send heartbeat")
 
 			def on_message(ws: WebSocketApp, message: str) -> None:
@@ -35138,7 +35141,10 @@ class RadioBox:
 
 				if d["op"] == 0:
 					self.ws_interval = d["d"]["heartbeat"] / 1000
-					ws.send("{\"op\":9}")
+					try:
+						ws.send('{"op":9}')
+					except Exception:
+						logging.info("Websocket already closed")
 
 				if d["op"] == 1:
 					try:
@@ -35156,21 +35162,23 @@ class RadioBox:
 						self.pctl.found_tags = found_tags
 						self.pctl.tag_meta = line
 
-						filename = d["d"]["song"]["albums"][0]["image"]
-						fulllink = "https://cdn.listen.moe/covers/" + filename
+						album_image = d["d"]["song"]["albums"][0].get("image")
+						if album_image:
+							filename = album_image
+							fulllink = "https://cdn.listen.moe/covers/" + filename
 
-						#logging.info(fulllink)
-						art_response = requests.get(fulllink, timeout=10)
-						#logging.info(art_response.status_code)
+							#logging.info(fulllink)
+							art_response = requests.get(fulllink, timeout=10)
+							#logging.info(art_response.status_code)
 
-						if art_response.status_code == 200:
-							if self.pctl.radio_image_bin:
-								self.pctl.radio_image_bin.close()
-								self.pctl.radio_image_bin = None
-							self.pctl.radio_image_bin = io.BytesIO(art_response.content)
-							self.pctl.radio_image_bin.seek(0)
-							self.dummy_track.art_url_key = "ok"
-							logging.info("Got new art")
+							if art_response.status_code == 200:
+								if self.pctl.radio_image_bin:
+									self.pctl.radio_image_bin.close()
+									self.pctl.radio_image_bin = None
+								self.pctl.radio_image_bin = io.BytesIO(art_response.content)
+								self.pctl.radio_image_bin.seek(0)
+								self.dummy_track.art_url_key = "ok"
+								logging.info("Got new art")
 
 					except Exception:
 						logging.exception("No image")

--- a/src/tauon/t_modules/t_stream.py
+++ b/src/tauon/t_modules/t_stream.py
@@ -364,8 +364,6 @@ class StreamEnc:
 						break
 			except Exception:
 				logging.exception("Feed not running!")
-				self.feed_running = False
-				raise
 			finally:
 				self.feed_running = False
 				self.close_pipe(decoder.stdin, "decoder stdin")


### PR DESCRIPTION
Fixes #943 , #1597 and #1842 

### Notes

**Issue #943 & #1597** - Radio crashes when switching stations due to `BrokenPipeError` in the feed thread. The `feed()` function in `t_stream.py:pump()` catches exceptions, logs them via `logging.exception()`, then re-raises, causing the daemon thread to crash instead of exiting gracefully.

**Issue #1842** - `WebSocketConnectionClosedException` crashes when switching away from listen.moe stations. The `send_heartbeat()` and op=0 handlers call `ws.send()` without handling closed connections. Additionally, when listen.moe sends track data with `image: null` in album info, the URL construction crashes with `TypeError`.

### Fixes applied:

**t_stream.py:365-369** - Removed `raise` after `logging.exception("Feed not running!")`. The finally block already sets `feed_running = False` and closes the pipe. The thread now exits gracefully on broken pipe errors during station switching.

**t_main.py:35125-35148** - Wrapped `ws.send()` calls in try-except blocks to handle `WebSocketConnectionClosedException` gracefully. Logs "Websocket already closed" when the connection is closed during station switching.

**t_main.py:35165-35172** - Added null check for album image before constructing cover URL. Uses `.get("image")` and only fetches if image exists, preventing TypeError when listen.moe sends null images.

### Testing

- py_compile passes for both
- Runtime: Play listen.moe radio, rapidly switch to SomaFM stations, verify clean transitions with "Websocket already closed" and "Feed not running!" log messages instead of crashes, here's my log file: 
[tauon_test.log](https://github.com/user-attachments/files/28677954/tauon_test.log)

### Log Notes

Pre-existing unrelated errors in the log file (not from these fixes):
- `KeyError: 'artistbackground'` — fanart lookup failures for artists without fanart
- `ResourceWarning: unclosed file` — decoder process cleanup warnings.