### PR TITLE
Fix Tidal return-type annotations: return_list yields track ids (list[int])

### DIFF
--- a/src/tauon/t_modules/t_tidal.py
+++ b/src/tauon/t_modules/t_tidal.py
@@ -221,7 +221,7 @@ class Tidal:
 		self.tauon.gui.pl_update += 14
 		return None
 
-	def fav_albums(self, return_list: bool = False) -> list[TrackClass] | None:
+	def fav_albums(self, return_list: bool = False) -> list[int] | None:
 		self.try_load()
 		if not self.session:
 			return []
@@ -247,7 +247,7 @@ class Tidal:
 		self.tauon.show_message("Playlist load complete", mode="done")
 		return None
 
-	def fav_tracks(self, return_list: bool = False) -> list[TrackClass] | None:
+	def fav_tracks(self, return_list: bool = False) -> list[int] | None:
 		self.try_load()
 		if not self.session:
 			return []
@@ -272,7 +272,7 @@ class Tidal:
 		self.tauon.show_message("Playlist load complete", mode="done")
 		return None
 
-	def playlist(self, id: str, return_list: bool = False) -> list[TrackClass] | None:
+	def playlist(self, id: str, return_list: bool = False) -> list[int] | None:
 		self.try_load()
 		if not self.session:
 			return []
@@ -296,7 +296,7 @@ class Tidal:
 		self.tauon.pctl.gen_codes[self.tauon.pl_to_id(len(self.tauon.pctl.multi_playlist) - 1)] = f'tpl"{id}"'
 		return None
 
-	def mix(self, id: str, return_list: bool = False) -> list[TrackClass] | None:
+	def mix(self, id: str, return_list: bool = False) -> list[int] | None:
 		self.try_load()
 		if not self.session:
 			return []
@@ -321,7 +321,7 @@ class Tidal:
 		self.tauon.pctl.gen_codes[self.tauon.pl_to_id(len(self.tauon.pctl.multi_playlist) - 1)] = f'tmix"{id}"'
 		return None
 
-	def artist(self, id: str, return_list: bool = False) -> list[TrackClass] | None:
+	def artist(self, id: str, return_list: bool = False) -> list[int] | None:
 		self.try_load()
 		if not self.session:
 			return []


### PR DESCRIPTION
Small typing correction toward #1338.

`Tidal.fav_albums`, `fav_tracks`, `playlist`, `mix`, and `artist` are annotated `-> list[TrackClass] | None`, but in their `return_list=True` branch they build and return a list of **track ids** (`nt.index`, an `int`), not `TrackClass` objects.

The call sites confirm this — `t_main.py` does `playlist.extend(self.tidal.<m>(return_list=True))` into a list of ids, and the sibling integrations (`subsonic.get_music3`, `plex.get_albums`) already annotate the same pattern as `list[int] | None`. Tidal was the lone outlier.

Corrects the five annotations to `list[int] | None`. No runtime change (`from __future__ import annotations`); resolves 5 mypy `[return-value]` errors in this module.
