### PR TITLE
fix(lyrics): use OggOpus for .opus tag writes (#2135)

### DIFF
--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -93,6 +93,7 @@ import mutagen.apev2
 import mutagen.flac
 import mutagen.id3
 import mutagen.mp4
+import mutagen.oggopus
 import mutagen.oggvorbis
 import requests
 import sdl3
@@ -9028,7 +9029,10 @@ class Tauon:
 			elif track.file_ext == "FLAC":
 				audio = mutagen.flac.FLAC(track.fullpath)
 				audio["SYNCEDLYRICS" if synced else "UNSYNCEDLYRICS"] = lyrics
-			elif track.file_ext in ("OPUS", "OGG"):
+			elif track.file_ext == "OPUS":
+				audio = mutagen.oggopus.OggOpus(track.fullpath)
+				audio["SYNCEDLYRICS" if synced else "UNSYNCEDLYRICS"] = lyrics
+			elif track.file_ext == "OGG":
 				audio = mutagen.oggvorbis.OggVorbis(track.fullpath)
 				audio["SYNCEDLYRICS" if synced else "UNSYNCEDLYRICS"] = lyrics
 			elif track.file_ext in ("APE","WV","TTA"):
@@ -43397,7 +43401,11 @@ class TimedLyricsEdit:
 			audio = mutagen.flac.FLAC(track.fullpath)
 			if any(key in audio for key in ("LYRICS", "SYNCEDLYRICS", "UNSYNCEDLYRICS")):
 				return True
-		elif track.file_ext in ("OPUS", "OGG"):
+		elif track.file_ext == "OPUS":
+			audio = mutagen.oggopus.OggOpus(track.fullpath)
+			if any(key in audio for key in ("LYRICS", "SYNCEDLYRICS", "UNSYNCEDLYRICS")):
+				return True
+		elif track.file_ext == "OGG":
 			audio = mutagen.oggvorbis.OggVorbis(track.fullpath)
 			if any(key in audio for key in ("LYRICS", "SYNCEDLYRICS", "UNSYNCEDLYRICS")):
 				return True


### PR DESCRIPTION
## What

Use `mutagen.oggopus.OggOpus` for `.opus` files when saving/checking embedded lyrics. `.ogg` files stay on `mutagen.oggvorbis.OggVorbis`.

## Why

Fixes #2135 — `write_lyrics()` lumped `OPUS` and `OGG` together and always opened files with `OggVorbis`, which fails on native Opus containers (`.opus`). That caused lyric save to fail and LRCLIB results to be skipped when "Save lyrics to file" is enabled.

The secondary `logging.exception()` misuse was already fixed upstream in 0d6ebd6.

## Scope

- `write_lyrics()` — split `OPUS` / `OGG` branches
- `will_overwrite_lyrics()` — same split (parity for overwrite prompt)

No runtime behavior change for `.ogg`. No rating-write paths touched (separate concern).

Closes #2135.
