### PR TITLE
Fix SDL3 lookup order on multilib Linux (Fedora/Nobara/RHEL/Rocky/Alma) etc...

### DIFF
--- a/src/tauon/__main__.py
+++ b/src/tauon/__main__.py
@@ -291,12 +291,12 @@ if sdl_dll_name:
 	candidates = [
 		"./" + sdl_dll_name,
 		os.path.join("/app/lib", sdl_dll_name),
-		os.path.join("/usr/lib", sdl_dll_name),
 		os.path.join("/usr/lib64", sdl_dll_name),
-		os.path.join("/lib", sdl_dll_name),
 		os.path.join("/lib64", sdl_dll_name),
-		os.path.join("/usr/local/lib", sdl_dll_name),
 		os.path.join("/usr/local/lib64", sdl_dll_name),
+		os.path.join("/usr/lib", sdl_dll_name),
+		os.path.join("/lib", sdl_dll_name),
+		os.path.join("/usr/local/lib", sdl_dll_name),
 	]
 else:
 	candidates = []


### PR DESCRIPTION
## Summary

Prefer 64-bit library directories before 32-bit ones when locating the system SDL3 library.

## Problem
On multilib Linux distributions such as Fedora-based ones, both of these libraries exist:
```
/usr/lib/libSDL3.so.0
/usr/lib64/libSDL3.so.0
```

The current lookup order checks `/usr/lib` before `/usr/lib64`, causing the 32-bit SDL3 library to be loaded on x86_64 systems. This results in: `OSError: wrong ELF class: ELFCLASS32`
## Solution
I spent some time fixing this because I was trying to do a Copr repo for Tauon. I had both `SDL3.x86_64` and `SDL3.i686` installed. What I ended up doing was; search the 64-bit library directories before the 32-bit ones while preserving the existing lookup logic.