### PR TITLE
Allow force-caching of certain large text textures

### DIFF
--- a/src/tauon/t_modules/t_draw.py
+++ b/src/tauon/t_modules/t_draw.py
@@ -430,9 +430,9 @@ class TDraw:
 		range_height: int | None = None,
 		real_bg: bool = False,
 		key: tuple[int, str, int, int, int, int, int, int, int, int] | None = None,
+		force_cache: bool = False,
 	) -> int:
 		# perf.set()
-		force_cache = False
 		if key:
 			force_cache = True
 
@@ -732,6 +732,7 @@ class TDraw:
 		range_height: int | None = None,
 		real_bg: bool = False,
 		key: tuple[int, str, int, int, int, int, int, int, int, int] | None = None,
+		force_cache: bool = False,
 	) -> int | None:
 		# logging.info((text, font))
 
@@ -767,6 +768,7 @@ class TDraw:
 					wrap=True,
 					range_top=range_top,
 					range_height=range_height,
+					force_cache=force_cache,
 				)
 
-		return self.__draw_text_cairo(location, text, colour, font, max_w, bg, align, real_bg=real_bg, key=key)
+		return self.__draw_text_cairo(location, text, colour, font, max_w, bg, align, real_bg=real_bg, key=key, force_cache=force_cache)

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -21305,7 +21305,7 @@ class LyricsRenMini:
 		#	 if inp.mouse_wheel > 0:
 		#		 prefs.lyrics_font_size -= 1
 
-		self.ddt.text((x, y, 4, w), self.text, colour, self.prefs.lyrics_font_size, w - (w % 2), bg)
+		self.ddt.text((x, y, 4, w), self.text, colour, self.prefs.lyrics_font_size, w - (w % 2), bg, force_cache=True)
 
 class LyricsRen:
 
@@ -21333,7 +21333,7 @@ class LyricsRen:
 		# if test_lumi(self.colours.lyrics_panel_background) < 0.5:
 		#	colour = self.colours.grey(40)
 		# TODO (Flynn): this used to check the gallery background & i don't even know why it did that much
-		self.ddt.text((x, y, 4, w), self.text, colour, 17, w, bg)
+		self.ddt.text((x, y, 4, w), self.text, colour, 17, w, bg, force_cache=True)
 
 class TimedLyricsToStatic:
 
@@ -35104,7 +35104,7 @@ class StandardPlaylist:
 				self.smooth_scroll.add_wheel_motion(
 					"playlist", -inp.mouse_wheel, gui.playlist_row_height * mx, SCROLL_PHYSICS_TRACKLIST_PRECISE_SCALE
 				)
-			
+
 			if inp.touch_released:
 				self.smooth_scroll.release_touch("playlist")
 			elif touch_scroll:
@@ -40898,7 +40898,8 @@ class ArtistInfoBox:
 			if width > 20 * scale:
 				self.ddt.text(
 					(text_x, text_top, 4, width, 14000), self.processed_text,
-					text_colour, 14.5, bg=background, range_height=text_area_h, range_top=self.scroll_y)
+					text_colour, 14.5, bg=background, range_height=text_area_h,
+					range_top=self.scroll_y, force_cache=True)
 
 			# Pin the link column to the top of the text region (below the image
 			# when stacked) so it never sits on top of the artwork.
@@ -45784,7 +45785,7 @@ class TimedLyricsEdit:
 
 		self.lyrics_position = max(self.lyrics_position, th * -1 + 100 * self.gui.scale)
 		self.lyrics_position = min(self.lyrics_position, 70 * self.gui.scale)
-		self.ddt.text((x, y + self.lyrics_position, 4, w), self.text, colour, self.font, w, bg)
+		self.ddt.text((x, y + self.lyrics_position, 4, w), self.text, colour, self.font, w, bg, force_cache=True)
 
 
 		widths = [


### PR DESCRIPTION
increases framerate and decreases cpu usage at the cost of taking more memory. Technically this could be a big deal and we do need some kind of hard cap but for 99% of cases this is a no brainer