### PR TITLE
Correct MEMU to MENU, remove . in sem.

### DIFF
--- a/locale/pt/LC_MESSAGES/tauon.po
+++ b/locale/pt/LC_MESSAGES/tauon.po
@@ -68,7 +68,7 @@ msgstr "d"
 
 #: src/tauon/t_modules/t_extra.py:573
 msgid "wk"
-msgstr "sem."
+msgstr "sem"
 
 #: src/tauon/t_modules/t_extra.py:575
 msgid "mnth"
@@ -3915,7 +3915,7 @@ msgstr "EMBARALHAR ALBUM"
 
 #: src/tauon/t_modules/t_main.py:30304
 msgid "MENU"
-msgstr "MEMU"
+msgstr "MENU"
 
 #: src/tauon/t_modules/t_main.py:30384
 msgid "It looks like something is being downloaded..."

--- a/locale/pt_BR/LC_MESSAGES/tauon.po
+++ b/locale/pt_BR/LC_MESSAGES/tauon.po
@@ -67,7 +67,7 @@ msgstr "d"
 
 #: src/tauon/t_modules/t_extra.py:573
 msgid "wk"
-msgstr "sem."
+msgstr "sem"
 
 #: src/tauon/t_modules/t_extra.py:575
 msgid "mnth"
@@ -3933,7 +3933,7 @@ msgstr "EMBARALHAR ALBUM"
 
 #: src/tauon/t_modules/t_main.py:30304
 msgid "MENU"
-msgstr "MEMU"
+msgstr "MENU"
 
 #: src/tauon/t_modules/t_main.py:30384
 msgid "It looks like something is being downloaded..."


### PR DESCRIPTION
Corrected the silly mistake (that I myself probably made):
It's MENU not MEMU!

And also removed "." from "sem." because of consistency

Sorry :man_facepalming: 