### PR TITLE
Correctly handle 'portable' override and mark CI releases as such

### DIFF
--- a/.github/workflows/build_and_release.yaml
+++ b/.github/workflows/build_and_release.yaml
@@ -94,6 +94,7 @@ jobs:
           source .venv/bin/activate
           pyinstaller --log-level=DEBUG packaging/pyinstaller/linux.spec
           ln -s _internal/libSDL3.so dist/TauonMusicBox/libSDL3.so.0
+          touch dist/TauonMusicBox/_internal/portable
 
       - name: Create 7Z
         run: |
@@ -397,6 +398,7 @@ jobs:
         run: |
           source .venv/bin/activate
           pyinstaller --log-level=DEBUG packaging/pyinstaller/windows.spec
+          touch dist/TauonMusicBox/_internal/portable
 
       - name: Create 7Z
         shell: msys2 {0}
@@ -417,6 +419,11 @@ jobs:
         with:
           name: TauonMusicBox-windows
           path: TauonMusicBox-windows.7z
+
+      - name: Remove portable flag
+        shell: msys2 {0}
+        run: |
+          rm dist/TauonMusicBox/_internal/portable
 
       - name: Replace Tauon version in .ISS
         run: |

--- a/src/tauon/__main__.py
+++ b/src/tauon/__main__.py
@@ -188,6 +188,7 @@ def transfer_args_and_exit() -> None:
 if "--no-start" in sys.argv:
 	transfer_args_and_exit()
 
+## TODO(Martin): This code is partially duped in t_main.py
 # If we're installed, use home data locations
 install_mode = bool(
 	str(install_directory).startswith(("/opt/", "/usr/", "/app/", "/snap/", "/nix/store/"))
@@ -201,7 +202,7 @@ if str(install_directory).startswith("/usr/") and Path("/usr/share/TauonMusicBox
 if (install_directory / "portable").is_file():
 	install_mode = False
 
-# Handle regular install, running from a directory and finally a portable install, usually a venv
+# Handle regular install, running from a git cloned directory and finally a portable install, usually a venv
 if install_mode:
 	# logging.info("Running in installed mode")
 	user_directory = Path(GLib.get_user_data_dir()) / "TauonMusicBox"

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -6895,7 +6895,7 @@ class Tauon:
 		sdl3.SDL_SetTrayIcon(self.sdl_tray, surf)
 
 
-	def sdl_set_tray_tooltip (self, tooltip: str) -> None:
+	def sdl_set_tray_tooltip(self, tooltip: str) -> None:
 		#logging.debug(f"Setting tray tooltip to '{tooltip}'")
 		sdl3.SDL_SetTrayTooltip(self.sdl_tray, tooltip.encode("utf-8"))
 
@@ -49437,11 +49437,22 @@ def main(holder: Holder) -> None:
 
 	download_directory = Path("~").expanduser() / "Downloads"
 
-	# Detect if we are installed or running portable
+	## Detect if we are installed or running portable
+	##   * Linux is set depending on which directory we're launching from
+	##   * Windows is assumed always installed
+	##   * macOS is assumed always installed
+	##   * Any of the above can be overriden by creating a file called 'portable' in the install directory
+	## TODO(Martin): This code is partially duped in __main__.py
 	install_mode = False
 	flatpak_mode = False
 	snap_mode = False
-	if str(install_directory).startswith(("/opt/", "/usr/", "/app/", "/snap/", "/nix/store/")):
+	# We do not have any fancy directory detection unlike on Linux, so just assume installed mode
+	if macos or windows:
+		install_mode = True
+	# Override to Portable mode if necessary
+	if (install_directory / "portable").is_file():
+		install_mode = False
+	elif str(install_directory).startswith(("/opt/", "/usr/", "/app/", "/snap/", "/nix/store/")):
 		install_mode = True
 		if str(install_directory)[:6] == "/snap/":
 			snap_mode = True
@@ -49451,12 +49462,10 @@ def main(holder: Holder) -> None:
 
 			# [old / no longer used] Symlink fontconfig from host system as workaround for poor font rendering
 			if os.path.exists(os.path.join(home_directory, ".var/app/com.github.taiko2k.tauonmb/config")):
-
 				host_fcfg = os.path.join(home_directory, ".config/fontconfig/")
 				flatpak_fcfg = os.path.join(home_directory, ".var/app/com.github.taiko2k.tauonmb/config/fontconfig")
 
 				if os.path.exists(host_fcfg):
-
 					# if os.path.isdir(flatpak_fcfg) and not os.path.islink(flatpak_fcfg):
 					#	 shutil.rmtree(flatpak_fcfg)
 					if os.path.islink(flatpak_fcfg):
@@ -49465,7 +49474,6 @@ def main(holder: Holder) -> None:
 					# else:
 					#	 logging.info("-- Symlinking user fonconfig")
 					#	 #os.symlink(host_fcfg, flatpak_fcfg)
-
 			flatpak_mode = True
 
 	logging.info(f"Platform: {sys.platform}")
@@ -49474,7 +49482,7 @@ def main(holder: Holder) -> None:
 		logging.info("Pyinstaller mode")
 
 	# If we're installed, use home data locations
-	if (install_mode) or macos or windows:
+	if install_mode:
 		cache_directory  = Path(GLib.get_user_cache_dir()) / "TauonMusicBox"
 		#user_directory   = Path(GLib.get_user_data_dir()) / "TauonMusicBox"
 		config_directory = user_directory
@@ -49494,7 +49502,6 @@ def main(holder: Holder) -> None:
 
 		if not (user_directory / "encoder").is_dir():
 			os.makedirs(user_directory / "encoder")
-
 	else:
 		logging.info("Running in portable mode")
 		config_directory = user_directory


### PR DESCRIPTION
Previously, we only used `portable` file to set the installation directory for the logs, and it was later ignored in `t_main.py`.

We ALSO critically did not create the `portable` file in portable CI builds, which was fine on Linux since it fell back onto the directory detection, but not so much on Windows.

This resulted in multiple bugs but the main problem is that Windows portable releases ALWAYS assumed the usual system installation directory by default, and always assumed cache directory was system directory even when `portable` override existed.

We should probably further rework this and do all the "is this portable" logic in `__main__`, and only read the value from this in `t_main.py` and do the necessary setting, as it is currently (and was previously) somewhat duped.

**This should be mentioned in release notes as a big warning**, specifically for Windows users using the portable releases, as they will suddenly correctly use `user-data` in the portable directory and not the system AppData dir `%APPDATA%\Local\TauonMusicBox`.