### PR TITLE
fix: Fix being unable to open files, revert to old syntax style

### DIFF
--- a/extra/com.github.taiko2k.tauonmb.sh
+++ b/extra/com.github.taiko2k.tauonmb.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 RESTORE=$(echo -en '\033[0m')
 RED=$(echo -en '\033[00;31m')
@@ -8,70 +9,53 @@ BLUE=$(echo -en '\033[00;34m')
 MAGENTA=$(echo -en '\033[00;35m')
 BOLD=$(echo -en '\033[1m')
 
-CONTROLLER_HOST="127.0.0.1"
-CONTROLLER_PORT="7813"
-BASE_URL="http://${CONTROLLER_HOST}:${CONTROLLER_PORT}"
+BASE_URL="http://127.0.0.1:7813"
 
 usage() {
-  cat <<EOF
+	cat <<EOF
 ${YELLOW}Usage:${RESTORE} $(basename "$0") [options] <command>
 
 ${BOLD}${MAGENTA}Commands:${RESTORE}
-  ${GREEN}play${RESTORE}          Starts playback
-  ${GREEN}pause${RESTORE}         Pauses playback
-  ${GREEN}playpause${RESTORE}     Toggle Play/Pause
-  ${GREEN}stop${RESTORE}          Stops playback entirely
-  ${GREEN}next${RESTORE}          Skips to the next track
-  ${GREEN}prev${RESTORE}          Skips to the previous track
-  ${GREEN}raise${RESTORE}         Brings the Tauon window to focus
-  ${GREEN}reloadtheme${RESTORE}   Reloads the active UI theme
-  ${GREEN}shuffle${RESTORE}       Toggles shuffle mode
-  ${GREEN}repeat${RESTORE}        Toggles repeat mode
+  ${GREEN}--play${RESTORE}          Starts playback
+  ${GREEN}--pause${RESTORE}         Pauses playback
+  ${GREEN}--playpause${RESTORE}     Toggle Play/Pause
+  ${GREEN}--stop${RESTORE}          Stops playback entirely
+  ${GREEN}--next${RESTORE}          Skips to the next track
+  ${GREEN}--previous${RESTORE}      Skips to the previous track
+  ${GREEN}--raise${RESTORE}         Brings the Tauon window to focus
+  ${GREEN}--reloadtheme${RESTORE}   Reloads the active UI theme
+  ${GREEN}--shuffle${RESTORE}       Toggles shuffle mode
+  ${GREEN}--repeat${RESTORE}        Toggles repeat mode
 
 ${BOLD}${MAGENTA}Options:${RESTORE}
   ${YELLOW}-h, --help${RESTORE}    Show this help message
 
-${BLUE}Example:${RESTORE} $(basename "$0") playpause
+${BLUE}Example:${RESTORE} $(basename "$0") --playpause
 EOF
-  exit 0
+	exit 0
 }
 
-while [[ "$#" -gt 0 ]]; do
-  case $1 in
-  -h | --help) usage ;;
-  -*)
-    echo -e "${RED}${BOLD}Error:${RESTORE} Unknown option: $1" >&2
-    usage
-    ;;
-  file://* | /*)
-    exec python3 /app/bin/src/tauon/__main__.py "$@"
-    ;;
-  *)
-    COMMAND=$1
-    shift
-    break
-    ;;
-  esac
+while [[ -n ${1-} ]]; do
+	case ${1} in
+		-h | --help)
+			usage
+			;;
+		--play | --pause | --playpause | --stop | --next | --previous | --raise | --reloadtheme | --shuffle | --repeat)
+			if ! RESPONSE=$(curl --fail --silent --show-error --output /dev/null --write-out "%{http_code}" "${BASE_URL}/${1#--}"); then
+				if [[ "${RESPONSE}" -ne 200 ]]; then
+					echo -e "${RED}${BOLD}Error:${RESTORE} Could not connect to Tauon. HTTP Status: ${RESPONSE}" >&2
+					echo -e "${YELLOW}Hint:${RESTORE} Make sure Tauon is running." >&2
+					exit 1
+				else
+					echo -e "${RED}${BOLD}Error:${RESTORE} Curl failed despite HTTP status 200 - THIS SHOULD NOT HAPPEN" >&2
+					exit 1
+				fi
+			fi
+			;;
+		*)
+			exec python3 /app/bin/src/tauon/__main__.py "$@"
+			;;
+	esac
 done
 
-if [ -z "$COMMAND" ]; then
-	exec python3 /app/bin/src/tauon/__main__.py "$@"
-fi
-
-case "$COMMAND" in
-play | pause | playpause | stop | next | prev | raise | reloadtheme | shuffle | repeat)
-  [ "$COMMAND" == "prev" ] && API_COMMAND="previous" || API_COMMAND="$COMMAND"
-
-  RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" "${BASE_URL}/${API_COMMAND}")
-
-  if [ "$RESPONSE" -ne 200 ]; then
-    echo -e "${RED}${BOLD}Error:${RESTORE} Could not connect to Tauon. (HTTP Status: $RESPONSE)" >&2
-    echo -e "${YELLOW}Hint:${RESTORE} Make sure Tauon is running." >&2
-    exit 1
-  fi
-  ;;
-*)
-  echo -e "${RED}${BOLD}Error:${RESTORE} Invalid command -> '$COMMAND'" >&2
-  usage
-  ;;
-esac
+exec python3 /app/bin/src/tauon/__main__.py "$@"

--- a/extra/tauonmb.sh
+++ b/extra/tauonmb.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 RESTORE=$(echo -en '\033[0m')
 RED=$(echo -en '\033[00;31m')
@@ -8,67 +9,53 @@ BLUE=$(echo -en '\033[00;34m')
 MAGENTA=$(echo -en '\033[00;35m')
 BOLD=$(echo -en '\033[1m')
 
-CONTROLLER_HOST="127.0.0.1"
-CONTROLLER_PORT="7813"
-BASE_URL="http://${CONTROLLER_HOST}:${CONTROLLER_PORT}"
+BASE_URL="http://127.0.0.1:7813"
 
 usage() {
-  cat <<EOF
+	cat <<EOF
 ${YELLOW}Usage:${RESTORE} $(basename "$0") [options] <command>
 
 ${BOLD}${MAGENTA}Commands:${RESTORE}
-  ${GREEN}play${RESTORE}          Starts playback
-  ${GREEN}pause${RESTORE}         Pauses playback
-  ${GREEN}playpause${RESTORE}     Toggle Play/Pause
-  ${GREEN}stop${RESTORE}          Stops playback entirely
-  ${GREEN}next${RESTORE}          Skips to the next track
-  ${GREEN}prev${RESTORE}          Skips to the previous track
-  ${GREEN}raise${RESTORE}         Brings the Tauon window to focus
-  ${GREEN}reloadtheme${RESTORE}   Reloads the active UI theme
-  ${GREEN}shuffle${RESTORE}       Toggles shuffle mode
-  ${GREEN}repeat${RESTORE}        Toggles repeat mode
+  ${GREEN}--play${RESTORE}          Starts playback
+  ${GREEN}--pause${RESTORE}         Pauses playback
+  ${GREEN}--playpause${RESTORE}     Toggle Play/Pause
+  ${GREEN}--stop${RESTORE}          Stops playback entirely
+  ${GREEN}--next${RESTORE}          Skips to the next track
+  ${GREEN}--previous${RESTORE}      Skips to the previous track
+  ${GREEN}--raise${RESTORE}         Brings the Tauon window to focus
+  ${GREEN}--reloadtheme${RESTORE}   Reloads the active UI theme
+  ${GREEN}--shuffle${RESTORE}       Toggles shuffle mode
+  ${GREEN}--repeat${RESTORE}        Toggles repeat mode
 
 ${BOLD}${MAGENTA}Options:${RESTORE}
   ${YELLOW}-h, --help${RESTORE}    Show this help message
 
-${BLUE}Example:${RESTORE} $(basename "$0") playpause
+${BLUE}Example:${RESTORE} $(basename "$0") --playpause
 EOF
-  exit 0
+	exit 0
 }
 
-while [[ "$#" -gt 0 ]]; do
-  case $1 in
-  -h | --help) usage ;;
-  -*)
-    echo -e "${RED}${BOLD}Error:${RESTORE} Unknown option: $1" >&2
-    usage
-    ;;
-  *)
-    COMMAND=$1
-    shift
-    break
-    ;;
-  esac
+while [[ -n ${1-} ]]; do
+	case ${1} in
+		-h | --help)
+			usage
+			;;
+		--play | --pause | --playpause | --stop | --next | --previous | --raise | --reloadtheme | --shuffle | --repeat)
+			if ! RESPONSE=$(curl --fail --silent --show-error --output /dev/null --write-out "%{http_code}" "${BASE_URL}/${1#--}"); then
+				if [[ "${RESPONSE}" -ne 200 ]]; then
+					echo -e "${RED}${BOLD}Error:${RESTORE} Could not connect to Tauon. HTTP Status: ${RESPONSE}" >&2
+					echo -e "${YELLOW}Hint:${RESTORE} Make sure Tauon is running." >&2
+					exit 1
+				else
+					echo -e "${RED}${BOLD}Error:${RESTORE} Curl failed despite HTTP status 200 - THIS SHOULD NOT HAPPEN" >&2
+					exit 1
+				fi
+			fi
+			;;
+		*)
+			exec tauonmb "${@}"
+			;;
+	esac
 done
 
-if [ -z "$COMMAND" ]; then
-  exec tauonmb "$@"
-fi
-
-case "$COMMAND" in
-play | pause | playpause | stop | next | prev | raise | reloadtheme | shuffle | repeat)
-  [ "$COMMAND" == "prev" ] && API_COMMAND="previous" || API_COMMAND="$COMMAND"
-
-  RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" "${BASE_URL}/${API_COMMAND}")
-
-  if [ "$RESPONSE" -ne 200 ]; then
-    echo -e "${RED}${BOLD}Error:${RESTORE} Could not connect to Tauon. (HTTP Status: $RESPONSE)" >&2
-    echo -e "${YELLOW}Hint:${RESTORE} Make sure Tauon is running." >&2
-    exit 1
-  fi
-  ;;
-*)
-  echo -e "${RED}${BOLD}Error:${RESTORE} Invalid command -> '$COMMAND'" >&2
-  usage
-  ;;
-esac
+exec tauonmb "${@}"


### PR DESCRIPTION
Fixes #2276

Reverts some of the changes that #2191 did.

* One can play files again by double clicking on them or launching them from CLI
* Errors from curl are shown
* `prev` is `previous` again
* commands are `--prefixed` again
* Remove setting useless variables
* `set -euo pipefail` to fail on failure/unset vars

