### PR TITLE
ci: Use GitHub tokens for docs/SDL

### DIFF
--- a/.github/workflows/build_and_release.yaml
+++ b/.github/workflows/build_and_release.yaml
@@ -63,6 +63,8 @@ jobs:
         # wget https://github.com/Taiko2k/Tauon/releases/download/Extras/liblcms2-dev_2.14-2build1_amd64.deb
 
       - name: Install Python dependencies and setup venv
+        env:
+          SDL_GITHUB_TOKEN: ${{ github.token }}
         run: |
           python -m pip install --upgrade pip
           python -m venv .venv

--- a/.github/workflows/pyright.yaml
+++ b/.github/workflows/pyright.yaml
@@ -61,6 +61,8 @@ jobs:
         #  wget http://mirrors.edge.kernel.org/ubuntu/pool/main/l/lcms2/liblcms2-dev_2.14-2build1_amd64.deb
 
       - name: Install Python dependencies and setup venv
+        env:
+          SDL_GITHUB_TOKEN: ${{ github.token }}
         run: |
           python -m pip install --upgrade pip
           python -m venv .venv


### PR DESCRIPTION
If we fail, we currently hammer SDL wiki to generate docs, which is far from ideal