### PR TITLE
fix(dbus): stop emitting duplicate Seeked signal, reset Position property on playback stop

### DIFF
--- a/src/tauon/t_modules/t_dbus.py
+++ b/src/tauon/t_modules/t_dbus.py
@@ -300,7 +300,6 @@ class MPRIS(dbus.service.Object):
 		self.pctl.seek_time(position / 1000000)
 
 		self.player_properties["Position"] = dbus.Int64(int(position))
-		self.Seeked(self.pctl.playing_time)
 
 	@dbus.service.method(dbus_interface="org.mpris.MediaPlayer2.Player")
 	def OpenUri(self, uri: str) -> None:

--- a/src/tauon/t_modules/t_dbus.py
+++ b/src/tauon/t_modules/t_dbus.py
@@ -101,6 +101,7 @@ class MPRIS(dbus.service.Object):
 			if self.player_properties["PlaybackStatus"] != "Stopped":
 				self.player_properties["PlaybackStatus"] = "Stopped"
 				changed["PlaybackStatus"] = self.player_properties["PlaybackStatus"]
+			self.player_properties["Position"] = dbus.Int64(0)
 		elif self.pctl.playing_state == PlayingState.PAUSED:
 			if self.player_properties["PlaybackStatus"] != "Paused":
 				self.player_properties["PlaybackStatus"] = "Paused"


### PR DESCRIPTION
This PR fixes two bugs (I didn't open two PRs, because it's only 2 lines of code) regarding MPRIS: previously, when seeking using the D-Bus `.Seek` function, Tauon would send a duplicate Seeked signal, but as a double and in seconds, instead of as int64 and in microseconds. Additionally, once playback stopped, the position returned from the D-Bus `Position` would remain stuck at the duration of the previously played song.