### PR TITLE
Fix playing DSD (Direct Stream Digital) and tag scanning

### DIFF
--- a/src/phazor/phazor.c
+++ b/src/phazor/phazor.c
@@ -3497,12 +3497,12 @@ int load_next_inner() {
 		case WAVPACK: {
 			char wv_error[80] = "";
 			if (is_net) {
-				wpc = WavpackOpenFileInputEx64(&bs_wv_reader, &bs, NULL, wv_error, OPEN_2CH_MAX, 0);
+				wpc = WavpackOpenFileInputEx64(&bs_wv_reader, &bs, NULL, wv_error, OPEN_2CH_MAX | OPEN_DSD_AS_PCM, 0);
 			} else {
 				// Keep the path based open for local files so the .wvc
 				// correction file keeps working
 				bs_close();
-				wpc = WavpackOpenFileInput(loaded_target_file, wv_error, OPEN_WVC | OPEN_2CH_MAX, 0);
+				wpc = WavpackOpenFileInput(loaded_target_file, wv_error, OPEN_WVC | OPEN_2CH_MAX | OPEN_DSD_AS_PCM, 0);
 			}
 			if (wpc == NULL) {
 				log_msg(LOG_ERROR, "pa: Error loading wavpak file (%s)", wv_error);

--- a/src/tauon/t_modules/t_tagscan.py
+++ b/src/tauon/t_modules/t_tagscan.py
@@ -948,10 +948,14 @@ class Ape(TrackFile):
 
 				# Found it
 				if s == b"APETAGEX":
-					found = 2
 					a.seek(-8, 1)
 					b = a.read(32)
-					footer = struct.unpack("<8c6i", b)
+					if len(b) == 32:
+						footer = struct.unpack("<8c6i", b)
+						found = 2
+					else:
+						logging.error("Tag Scanner: Found incomplete APE tag footer")
+						break
 
 		if found == 0:
 			logging.info("Tag Scanner: Can't find APE tag")


### PR DESCRIPTION
Enable playing DSD files by setting `OPEN_DSD_AS_PCM`.

Don't crash tagscan when encountering a broken APE tag - just log it instead.

Fixes issues mentioned in https://github.com/Taiko2k/Tauon/discussions/2298.