### PR TITLE
Fix reading album art from APE tags for .wv and .tta

### DIFF
--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -23814,7 +23814,7 @@ class AlbumArt:
 				tag.read(True)
 				if tag.has_picture and len(tag.picture) > 30:
 					pic = tag.picture
-		elif track.file_ext == "APE":
+		elif track.file_ext in ("APE", "WV", "TTA"):
 			with Ape(filepath) as tag:
 				tag.read()
 				if tag.has_picture and len(tag.picture) > 30:


### PR DESCRIPTION
Looks like we ignored WV and TTA for reading album art.

Fixes an issue reported in https://github.com/Taiko2k/Tauon/discussions/2298