### PR TITLE
Build releases for Linux arm64 too

### DIFF
--- a/.github/release_body.md
+++ b/.github/release_body.md
@@ -29,6 +29,7 @@ Please report any issues either over at [Discord](https://discord.gg/v4EmhES) or
 			<tr>
 				<td>Linux</td>
 				<td>
+					<a href="https://github.com/Taiko2k/Tauon/releases/download/RELEASE_TAG/TauonMusicBox-linux-arm64.7z"><img src="https://img.shields.io/badge/Portable-arm64-f84e29.svg?logo=linux"> </a><br>
 					<a href="https://github.com/Taiko2k/Tauon/releases/download/RELEASE_TAG/TauonMusicBox-linux.7z"><img src="https://img.shields.io/badge/Portable-x64-f84e29.svg?logo=linux"> </a><br>
 					<a href="https://github.com/Taiko2k/Tauon/releases/download/RELEASE_TAG/TauonMusicBox-x64.flatpak"><img src="https://img.shields.io/badge/Flatpak-x64-FF9966.svg?logo=flatpak"> </a><br>
 				</td>

--- a/.github/workflows/build_and_release.yaml
+++ b/.github/workflows/build_and_release.yaml
@@ -5,8 +5,120 @@ on:
   pull_request:
 
 jobs:
-  build-linux:
-    name: "Linux"
+  build-linux-arm64:
+    name: "Linux arm64"
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v7
+        with:
+          submodules: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.14'
+          cache: 'pip'
+
+      - name: Install deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            gettext \
+            gobject-introspection \
+            gir1.2-rsvg-2.0 \
+            gir1.2-notify-0.7 \
+            gir1.2-girepository-3.0-dev \
+            kde-config-gtk-style \
+            libcanberra-gtk3-module \
+            libgirepository1.0-dev \
+            libgirepository-2.0-dev \
+            libglib2.0-dev \
+            python3-gi-cairo \
+            libayatana-appindicator3-dev \
+            libcairo2-dev \
+            libpipewire-0.3-dev \
+            libdbus-1-dev \
+            libjxl-dev \
+            libflac-dev \
+            libgme-dev \
+            libmpg123-dev \
+            libopenmpt-dev \
+            libopusfile-dev \
+            libsamplerate0-dev \
+            libvorbis-dev \
+            libwavpack-dev \
+            p7zip
+          # JPEG-XL hack since 24.04 is too old
+          sudo apt-get install -y \
+            libgif7 \
+            liblcms2-dev \
+            wget
+          wget https://github.com/Taiko2k/Tauon/releases/download/Extras/libjxl-dev_0.10.3-4ubuntu1_arm64.deb
+          wget https://github.com/Taiko2k/Tauon/releases/download/Extras/libjxl0.10_0.10.3-4ubuntu1_arm64.deb
+          wget https://github.com/Taiko2k/Tauon/releases/download/Extras/libhwy-dev_1.2.0-3ubuntu2_arm64.deb
+          wget https://github.com/Taiko2k/Tauon/releases/download/Extras/libhwy1t64_1.2.0-3ubuntu2_arm64.deb
+          curl -L -o lrclib-solver https://github.com/Taiko2k/Tauon/releases/download/Extras/lrclib-solver-linux-arm64
+          sudo dpkg -i *.deb
+
+      - name: Install Python dependencies and setup venv
+        env:
+          SDL_GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python -m pip install --upgrade pip
+          python -m venv .venv
+          source .venv/bin/activate
+          pip install \
+            ".[all]" \
+            build \
+            pyinstaller
+          python -c "import sdl3"
+        #    https://github.com/pyinstaller/pyinstaller/archive/develop.zip
+
+      - name: Build the project using python-build
+        run: |
+          source .venv/bin/activate
+          python -m tools.i18n.compile_translations
+          python -m build --wheel
+
+      - name: Install the project into a venv
+        run: |
+          source .venv/bin/activate
+          pip install --prefix ".venv" dist/*.whl
+
+      - name: "[DEBUG] List all files"
+        run: find .
+
+      # (Martin): ln hack is due to https://github.com/Taiko2k/Tauon/issues/2052
+      - name: Build Linux App with PyInstaller
+        run: |
+          source .venv/bin/activate
+          pyinstaller --log-level=DEBUG packaging/pyinstaller/linux.spec
+          ln -s _internal/libSDL3.so dist/TauonMusicBox/libSDL3.so.0
+          touch dist/TauonMusicBox/_internal/portable
+
+      - name: Create 7Z
+        run: |
+          APP_NAME="TauonMusicBox"
+          cd "dist/${APP_NAME}"
+
+          ARCHIVE_PATH="../../${APP_NAME}-linux-arm64.7z"
+
+          7z a -r -snl "${ARCHIVE_PATH}" "."
+
+      - name: Upload 7Z artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: TauonMusicBox-linux-arm64
+          path: TauonMusicBox-linux-arm64.7z
+
+      #- name: Run Tauon for testing
+      #  run: |
+      #    source .venv/bin/activate
+      #    tauonmb
+
+  build-linux-x64:
+    name: "Linux x64"
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout source code
@@ -58,7 +170,7 @@ jobs:
           wget https://github.com/Taiko2k/Tauon/releases/download/Extras/libjxl0.10_0.10.3-4ubuntu1_amd64.deb
           wget https://github.com/Taiko2k/Tauon/releases/download/Extras/libhwy-dev_1.2.0-3ubuntu2_amd64.deb
           wget https://github.com/Taiko2k/Tauon/releases/download/Extras/libhwy1t64_1.2.0-3ubuntu2_amd64.deb
-          curl -L -o lrclib-solver https://github.com/Taiko2k/Tauon/releases/download/Extras/lrclib-solver-linux
+          curl -L -o lrclib-solver https://github.com/Taiko2k/Tauon/releases/download/Extras/lrclib-solver-linux-x64
           sudo dpkg -i *.deb
         # wget https://github.com/Taiko2k/Tauon/releases/download/Extras/liblcms2-dev_2.14-2build1_amd64.deb
 
@@ -118,8 +230,10 @@ jobs:
       #    source .venv/bin/activate
       #    tauonmb
 
-  build-macos:
-    name: "macOS"
+  build-macos-arm64:
+    name: "macOS arm64"
+    # Keep lowest version we can reasonably build on,
+    # as that's the resulting minimally-supported macOS version in the built app
     runs-on: macos-15
     env:
       # Pinned projectM master for the Milkdrop visualiser library
@@ -171,7 +285,7 @@ jobs:
 
       - name: Download lirclib solver
         run: |
-          curl -L -o lrclib-solver https://github.com/Taiko2k/Tauon/releases/download/Extras/lrclib-solver-macos
+          curl -L -o lrclib-solver https://github.com/Taiko2k/Tauon/releases/download/Extras/lrclib-solver-macos-arm64
 
       - name: Build macOS Now Playing helper
         run: |
@@ -290,8 +404,8 @@ jobs:
       #    hdiutil attach dist/dmg/Tauon.dmg
       #    /Volumes/Tauon/Tauon.app/Contents/MacOS/Tauon
 
-  build-windows:
-    name: "Windows"
+  build-windows-x64:
+    name: "Windows x64"
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -378,8 +492,7 @@ jobs:
       - name: Download optionals from latest release files and notofonts' GitHub
         shell: msys2 {0}
         run: |
-          curl -L -o lrclib-solver.exe https://github.com/Taiko2k/Tauon/releases/download/Extras/lrclib-solver.exe
-          curl -L -o librespot.exe  https://github.com/Taiko2k/Tauon/releases/download/Extras/librespot.exe # v0.6.0 - https://github.com/librespot-org/librespot/releases
+          curl -L -o lrclib-solver.exe https://github.com/Taiko2k/Tauon/releases/download/Extras/lrclib-solver-x64.exe
           curl -L -o TauonSMTC.dll  https://github.com/Taiko2k/Tauon/releases/download/Extras/TauonSMTC.dll
           mkdir fonts
           curl -L -o fonts/NotoSans-ExtraCondensed.ttf     https://github.com/notofonts/notofonts.github.io/raw/refs/heads/main/fonts/NotoSans/full/ttf/NotoSans-ExtraCondensed.ttf     # 800KB
@@ -462,7 +575,7 @@ jobs:
           path: extra/Output/TauonMusicBox-windows-installer.exe
 
   get-info:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     outputs:
       date: ${{ steps.vars.outputs.date }}
       shorthash: ${{ steps.vars.outputs.shorthash }}
@@ -481,8 +594,8 @@ jobs:
 
   pre-release:
     if: github.ref == 'refs/heads/master' && github.repository == 'Taiko2k/Tauon' && github.event_name == 'push'
-    needs: [get-info, build-linux, build-windows, build-macos]
-    runs-on: ubuntu-24.04
+    needs: [get-info, build-linux-arm64, build-linux-x64, build-windows-x64, build-macos-arm64]
+    runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v8

--- a/.github/workflows/build_extras.yaml
+++ b/.github/workflows/build_extras.yaml
@@ -4,63 +4,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-windows-librespot_exe:
-    name: "librespot.exe"
-    runs-on: windows-latest
-    steps:
-      - name: Checkout source code
-        uses: actions/checkout@v7
-
-      - name: Set up MSYS2 MinGW-W64
-        uses: msys2/setup-msys2@v2
-        with:
-          msystem: mingw64
-          update: true
-          install: >-
-            cmake
-            make
-            ninja
-            mingw-w64-x86_64-cmake
-            mingw-w64-x86_64-gcc
-            mingw-w64-x86_64-make
-            mingw-w64-x86_64-nasm
-            mingw-w64-x86_64-ninja
-            mingw-w64-x86_64-openssl
-            mingw-w64-x86_64-pkg-config
-            mingw-w64-x86_64-pkgconf
-            mingw-w64-x86_64-rust
-
-      #- name: "[DEBUG] List all packages"
-      #  shell: msys2 {0}
-      #  run: pacman -Q
-
-      # C:\Users\runneradmin\.cargo\bin\librespot.exe
-      - name: Install librespot with cargo
-        shell: msys2 {0}
-        run: |
-          cargo install librespot
-
-      #- name: "[DEBUG] List all files"
-      #  shell: msys2 {0}
-      #  run: find .
-
-      #- name: Get current drive letter for cargo bin
-      #  shell: pwsh
-      #  run: |
-      #    $Drive = (Get-Item -Path "${{ github.workspace }}").PSDrive.Name + ":\"
-      #    $BinPath = Join-Path $Drive "Users\runneradmin\.cargo\bin\librespot.exe"
-      #    Write-Output "##vso[task.setvariable variable=LibrespotPath]$BinPath"
-
-      - name: Upload librespot.exe artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: librespot-windows
-          path: C:\Users\runneradmin\.cargo\bin\librespot.exe # ${{ env.LibrespotPath }}
-          if-no-files-found: error
-          retention-days: 14
-
-  build-windows-lrclib_solver_exe:
-    name: "lrclib-solver.exe"
+  build-windows-x64-lrclib_solver_exe:
+    name: "lrclib-solver-x64.exe"
     runs-on: windows-latest
     steps:
       - name: Checkout source code
@@ -93,76 +38,8 @@ jobs:
       - name: Upload lrclib-solver.exe artifact
         uses: actions/upload-artifact@v7
         with:
-          name: lrclib-solver-windows
+          name: lrclib-solver-windows-x64
           path: src/lrclib-solver/target/release/lrclib-solver.exe
-          if-no-files-found: error
-          retention-days: 14
-
-  build-windows-TaskbarLib_tlb:
-    name: "TaskbarLib.tlb"
-    runs-on: windows-latest
-    steps:
-      - name: Checkout source code
-        uses: actions/checkout@v7
-
-      - name: Locate Windows SDK
-        shell: pwsh
-        run: |
-          $kitsRoot10 = (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows Kits\Installed Roots' 'KitsRoot10').KitsRoot10
-          if (-not $kitsRoot10) { throw 'Windows SDK root not found.' }
-
-          $includeDir = Join-Path $kitsRoot10 'Include'
-          $pick = Get-ChildItem -Path $includeDir -Directory |
-            Where-Object {
-              (Test-Path (Join-Path $_.FullName 'um')) -and
-              (Test-Path (Join-Path $_.FullName 'shared'))
-            } |
-            Sort-Object Name -Descending |
-            Select-Object -First 1
-
-          if (-not $pick) { throw "No suitable SDK version found under $includeDir." }
-          $sdkVer = $pick.Name
-
-          $sdkBinX64 = Join-Path $kitsRoot10 "bin\$sdkVer\x64"
-          $incUm     = Join-Path $includeDir "$sdkVer\um"
-          $incShared = Join-Path $includeDir "$sdkVer\shared"
-
-          if (-not (Test-Path (Join-Path $sdkBinX64 'midl.exe'))) {
-            throw "midl.exe not found in $sdkBinX64"
-          }
-
-          "WIN_SDK_BIN_X64=$sdkBinX64"    | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-          "WIN_SDK_INC_UM=$incUm"         | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-          "WIN_SDK_INC_SHARED=$incShared" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-
-      - name: Locate VS Dev Cmd (sets up cl.exe, INCLUDE/LIB)
-        shell: pwsh
-        run: |
-          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-          if (-not (Test-Path $vswhere)) { throw "vswhere.exe not found at $vswhere" }
-          $vsRoot = & $vswhere -latest -products * `
-            -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
-            -property installationPath
-          if (-not $vsRoot) { throw "Visual Studio with VC tools not found." }
-          $vsDevCmd = Join-Path $vsRoot "Common7\Tools\VsDevCmd.bat"
-          if (-not (Test-Path $vsDevCmd)) { throw "VsDevCmd.bat not found at $vsDevCmd" }
-          "VSDEVCMD=$vsDevCmd" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-
-      - name: Compile TaskbarLib.idl -> TaskbarLib.tlb (MIDL)
-        shell: cmd
-        run: |
-          call "%VSDEVCMD%" -arch=x64 -host_arch=x64
-          set "PATH=%PATH%;%WIN_SDK_BIN_X64%"
-          cd extra
-          midl.exe /I "%WIN_SDK_INC_UM%" /I "%WIN_SDK_INC_SHARED%" TaskbarLib.idl
-          if errorlevel 1 exit /b %errorlevel%
-
-      # Upload TaskbarLib.tlb as artifact
-      - name: Upload TaskbarLib.tlb artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: TaskbarLib-tlb
-          path: extra\TaskbarLib.tlb
           if-no-files-found: error
           retention-days: 14
 
@@ -216,8 +93,8 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
-  build-linux-lrclib_solver:
-    name: "Linux lrclib-solver"
+  build-linux-x64-lrclib_solver:
+    name: "Linux x64 lrclib-solver"
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout source code
@@ -236,13 +113,38 @@ jobs:
       - name: Upload lrclib-solver artifact
         uses: actions/upload-artifact@v7
         with:
-          name: lrclib-solver-linux
+          name: lrclib-solver-linux-x64
           path: src/lrclib-solver/target/release/lrclib-solver
           if-no-files-found: error
           retention-days: 14
 
-  build-macOS-lrclib_solver:
-    name: "macOS lrclib-solver"
+  build-linux-arm64-lrclib_solver:
+    name: "Linux arm64 lrclib-solver"
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v7
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          components: clippy,rustfmt
+
+      - name: Build lrclib-solver
+        run: |
+          cargo build --release --manifest-path src/lrclib-solver/Cargo.toml --bin lrclib-solver
+
+      - name: Upload lrclib-solver artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: lrclib-solver-linux-arm64
+          path: src/lrclib-solver/target/release/lrclib-solver
+          if-no-files-found: error
+          retention-days: 14
+
+  build-macOS-arm64-lrclib_solver:
+    name: "macOS arm64 lrclib-solver"
     runs-on: macos-latest
     steps:
       - name: Checkout source code
@@ -261,7 +163,7 @@ jobs:
       - name: Upload lrclib-solver artifact
         uses: actions/upload-artifact@v7
         with:
-          name: lrclib-solver-macos
+          name: lrclib-solver-macos-arm64
           path: src/lrclib-solver/target/release/lrclib-solver
           if-no-files-found: error
           retention-days: 14

--- a/packaging/pyinstaller/linux.spec
+++ b/packaging/pyinstaller/linux.spec
@@ -8,9 +8,15 @@ REPO_ROOT = SPEC_DIR.parents[1]
 
 python_ver = f"{sys.version_info.major}.{sys.version_info.minor}"
 
-ubuntu_lib_path = "/usr/lib/x86_64-linux-gnu"
+ubuntu_x64_lib_path = "/usr/lib/x86_64-linux-gnu"
+ubuntu_arm64_lib_path = "/usr/lib/aarch64-linux-gnu"
 arch_lib_path = "/usr/lib"
-lib_path = ubuntu_lib_path if Path(ubuntu_lib_path).exists() else arch_lib_path
+if Path(ubuntu_x64_lib_path).exists():
+	lib_path = ubuntu_x64_lib_path
+elif Path(ubuntu_arm64_lib_path).exists():
+	lib_path = ubuntu_arm64_lib_path
+else:
+	lib_path = arch_lib_path
 
 a = Analysis(
 	[str(REPO_ROOT / "src/tauon/__main__.py")],

--- a/run.sh
+++ b/run.sh
@@ -21,13 +21,6 @@ win_build() {
 	rm -rf dist/tauon/share/{icons,locale,tcl/tzdata} dist/TauonMusicBox/tcl/tzdata
 	cp -r fonts dist/tauon/ || echo 'fonts directory is not present!'
 	cp -r /mingw64/etc/fonts dist/TauonMusicBox/etc # TODO(Martin): Why is this here?
-	if [[ -e TaskbarLib.tlb ]]; then
-		cp TaskbarLib.tlb dist/TauonMusicBox/
-	elif [[ -e extra/TaskbarLib.tlb ]]; then
-		cp extra/TaskbarLib.tlb dist/TauonMusicBox/TaskbarLib.tlb
-	else
-		echo 'TaskbarLib.tlb is not present!'
-	fi
 	echo -e "Packaged to dist/TauonMusicBox"
 }
 


### PR DESCRIPTION
Add arm64 portable to match what we ship with Flatpak.

Delete librespot.exe build from CI since support has been dropped.

Stop packaging downloading librespot.exe in the Windows CI builds.

Remove TaskbarLib remainders from everywhere.

EDIT: Currently broken on Wayland Linux arm64 since SDL3 we put in there is not built with Wayland support

EDIT2: Wayland support fixed by https://github.com/Aermoss/PySDL3-Build/pull/1