### PR TITLE
Bump to Gtk 4.0

### DIFF
--- a/.github/workflows/build_and_release.yaml
+++ b/.github/workflows/build_and_release.yaml
@@ -30,7 +30,6 @@ jobs:
             gir1.2-notify-0.7 \
             gir1.2-girepository-3.0-dev \
             kde-config-gtk-style \
-            libcanberra-gtk3-module \
             libgirepository1.0-dev \
             libgirepository-2.0-dev \
             libglib2.0-dev \
@@ -39,6 +38,7 @@ jobs:
             libcairo2-dev \
             libpipewire-0.3-dev \
             libdbus-1-dev \
+            libgtk-4-common \
             libjxl-dev \
             libflac-dev \
             libgme-dev \
@@ -142,7 +142,6 @@ jobs:
             gir1.2-notify-0.7 \
             gir1.2-girepository-3.0-dev \
             kde-config-gtk-style \
-            libcanberra-gtk3-module \
             libgirepository1.0-dev \
             libgirepository-2.0-dev \
             libglib2.0-dev \
@@ -151,6 +150,7 @@ jobs:
             libcairo2-dev \
             libpipewire-0.3-dev \
             libdbus-1-dev \
+            libgtk-4-common \
             libjxl-dev \
             libflac-dev \
             libgme-dev \

--- a/packaging/pyinstaller/linux.spec
+++ b/packaging/pyinstaller/linux.spec
@@ -24,10 +24,6 @@ a = Analysis(
 	binaries=[],
 	datas=[
 		(certifi.where(), "certifi"),
-		(f"{lib_path}/gtk-3.0/modules/libcolorreload-gtk-module.so", "lib/gtk-3.0/modules"),
-		(f"{lib_path}/gtk-3.0/modules/libwindow-decorations-gtk-module.so", "lib/gtk-3.0/modules"),
-		(f"{lib_path}/gtk-3.0/modules/libcanberra-gtk-module.so", "lib/gtk-3.0/modules"),
-		(f"{lib_path}/gtk-3.0/modules/libcanberra-gtk3-module.so", "lib/gtk-3.0/modules"),
 		(f"{lib_path}/girepository-1.0/Notify-0.7.typelib", "gi_typelibs"),
 		(str(REPO_ROOT / ".venv/lib/python3.14/site-packages/sdl3/bin/libSDL3.so"), "."),
 		(str(REPO_ROOT / ".venv/lib/python3.14/site-packages/sdl3/bin/libSDL3_image.so"), "."),

--- a/src/tauon/__main__.py
+++ b/src/tauon/__main__.py
@@ -412,8 +412,7 @@ else:
 # if d == "GNOME": #and os.environ.get("XDG_SESSION_TYPE") and os.environ.get("XDG_SESSION_TYPE") == "wayland":
 # 	try:
 # 		import gi.repository
-# 		# TODO(Martin): Bump to 4.0 - https://github.com/Taiko2k/Tauon/issues/1316
-# 		gi.require_version("Gtk", "3.0")
+# 		gi.require_version("Gtk", "4.0")
 # 		from gi.repository import Gtk
 #
 #

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -52540,8 +52540,7 @@ def main(holder: Holder) -> None:
 	mac_maximize = ColourRGBA(254, 176, 36, 255)
 	mac_minimize = ColourRGBA(42, 189, 49, 255)
 	try:
-		# TODO(Martin): Bump to 4.0 - https://github.com/Taiko2k/Tauon/issues/1316
-		gi.require_version("Gtk", "3.0")
+		gi.require_version("Gtk", "4.0")
 		from gi.repository import Gtk
 
 		gtk_settings = Gtk.Settings().get_default()


### PR DESCRIPTION
Fixes #1316

We need to wait til SDL 3.6.0 releases.

We will also need to bump the CI to install 4.0 instead of 3.0 and the spec files.