### PR TITLE
Add Cosmic-Comp to the list of compositors that support the "ext-brackground-effect-v1" protocol.

### DIFF
--- a/src/tauon/t_modules/t_wayland_blur.py
+++ b/src/tauon/t_modules/t_wayland_blur.py
@@ -1,7 +1,7 @@
 """Background blur behind the window on Wayland
 
 Implements ``ext-background-effect-v1`` (KWin 6.7+, Hyprland 0.56+, niri
-26.04+, Mutter 51+) so the compositor blurs behind Tauon while a glass style
+26.04+, Mutter 51+, Cosmic-Comp 1.3.0+) so the compositor blurs behind Tauon while a glass style
 is selected. Hyprland no longer blurs translucent windows unless asked
 through this protocol.
 


### PR DESCRIPTION
Since COSMIC/Cosmic-Comp supports the "ext-brackground-effect-v1" protocol since version 1.3.0, I've added it to the list of compositor that support it.

The blur effect in Tauon is working on the COSMIC DE, as you can see from https://github.com/Taiko2k/Tauon/issues/2321#issuecomment-5585858185