### PR TITLE
Stop dbus mainloop before destroying tray on exit

### DIFF
--- a/src/tauon/t_modules/t_dbus.py
+++ b/src/tauon/t_modules/t_dbus.py
@@ -334,6 +334,7 @@ class Gnome:
 		self.bus_object = None
 		self.tauon: Tauon = tauon
 		self.resume_playback: bool = False
+		self.mainloop: GLib.MainLoop | None = None
 
 	def focus(self) -> None:
 		if self.bus_object is not None:
@@ -467,5 +468,5 @@ class Gnome:
 			except Exception:
 				logging.exception("MPRIS2 CONNECT FAILED")
 
-		mainloop = GLib.MainLoop()
-		mainloop.run()
+		self.mainloop = GLib.MainLoop()
+		self.mainloop.run()

--- a/src/tauon/t_modules/t_main.py
+++ b/src/tauon/t_modules/t_main.py
@@ -7178,6 +7178,7 @@ class Tauon:
 		self.art_box:                             ArtBox = ArtBox(tauon=self)
 		self.nagbox:                              NagBox = NagBox(tauon=self)
 
+		self.gnome_thread: threading.Thread | None = None
 		if not self.macos and not self.windows:
 			self.gnome = Gnome(tauon=self)
 
@@ -54433,9 +54434,9 @@ def main(holder: Holder) -> None:
 
 	if not macos and not tauon.windows:
 		try:
-			gnome_thread = threading.Thread(target=tauon.gnome.main)
-			gnome_thread.daemon = True
-			gnome_thread.start()
+			tauon.gnome_thread = threading.Thread(target=tauon.gnome.main)
+			tauon.gnome_thread.daemon = True
+			tauon.gnome_thread.start()
 		except Exception:
 			logging.exception("Could not start Dbus thread")
 
@@ -62590,6 +62591,17 @@ def main(holder: Holder) -> None:
 
 	# sdl3.IMG_Quit()
 	# sdl3.SDL_QuitSubSystem(sdl3.SDL_INIT_EVERYTHING)
+	if getattr(tauon, "gnome", None) is not None and tauon.gnome.mainloop is not None:
+		GLib.idle_add(tauon.gnome.mainloop.quit)
+		if tauon.gnome_thread is not None:
+			tauon.gnome_thread.join(timeout=2)
+
+			if tauon.gnome_thread.is_alive():
+				logging.warning("Dbus thread did not stop within 2s")
+
+	if tauon.sdl_tray is not None:
+		tauon.destroy_sdl_tray()
+
 	sdl3.SDL_Quit()
 	# logging.info("SDL unloaded")
 


### PR DESCRIPTION
Fixes #2327

The dbus/MPRIS thread runs a `GLib.MainLoop` that services the SDL tray's libdbusmenu events. It was a daemon thread that was never stopped, so on exit `SDL_Quit` freed the tray objects while that thread could still be dispatching callbacks on them, causing an intermittent segfault.

This change:
- keeps the `GLib.MainLoop` as an attribute on `Gnome` so it can be stopped
- keeps a reference to the dbus thread on `Tauon`
- on exit, quits the loop via `GLib.idle_add`, joins the thread with a 2s timeout (logging a warning if it does not stop), destroys the tray explicitly, and only then calls `SDL_Quit`