### PR TITLE
Don't use linear volume in listen along volume slider

### DIFF
--- a/src/tauon/templates/radio.js
+++ b/src/tauon/templates/radio.js
@@ -36,7 +36,8 @@ setServerIcons(mode=0);
 vol_slider = document.getElementById("vol-slider");
 
 function volChange() {
-    sound.volume = vol_slider.value / 100;
+    // Don't use linear volume: https://www.dr-lex.be/info-stuff/implement-a-volume-control.html
+    sound.volume = Math.pow(vol_slider.value / 100, 1.7)
 }
 
 vol_slider.addEventListener("input", volChange, false);


### PR DESCRIPTION
The default linear volume makes most of the volume slider be way too loud, making only the bottom 30% really usable.
Using powers is a decent approximation for the exponential curve that would be ideal:
https://www.dr-lex.be/info-stuff/implement-a-volume-control.html

I tried out a few different powers, 2 and 3 seemed to make the low end of the slider become muted while the slider was not at 0.
1.7 seemed like a good compromise.
